### PR TITLE
Write Infinity and NaN floats as strings

### DIFF
--- a/jsonplugin/marshal.go
+++ b/jsonplugin/marshal.go
@@ -6,6 +6,7 @@ package jsonplugin
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -157,12 +158,34 @@ func (s *MarshalState) WriteFloat32(v float32) {
 	if s.Err() != nil {
 		return
 	}
+	switch {
+	case math.IsInf(float64(v), 1):
+		s.inner.WriteString("Infinity")
+		return
+	case math.IsInf(float64(v), -1):
+		s.inner.WriteString("-Infinity")
+		return
+	case math.IsNaN(float64(v)):
+		s.inner.WriteString("NaN")
+		return
+	}
 	s.inner.WriteFloat32(v)
 }
 
 // WriteFloat64 writes a float64 value.
 func (s *MarshalState) WriteFloat64(v float64) {
 	if s.Err() != nil {
+		return
+	}
+	switch {
+	case math.IsInf(v, 1):
+		s.inner.WriteString("Infinity")
+		return
+	case math.IsInf(v, -1):
+		s.inner.WriteString("-Infinity")
+		return
+	case math.IsNaN(v):
+		s.inner.WriteString("NaN")
 		return
 	}
 	s.inner.WriteFloat64(v)

--- a/jsonplugin/marshal_test.go
+++ b/jsonplugin/marshal_test.go
@@ -4,6 +4,7 @@
 package jsonplugin_test
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -48,6 +49,30 @@ func TestMarshaler(t *testing.T) {
 	testMarshal(t, func(s *MarshalState) {
 		s.WriteFloat64Array([]float64{-12.34, 56.78})
 	}, `[-12.34,56.78]`)
+
+	testMarshal(t, func(s *MarshalState) {
+		s.WriteFloat32(float32(math.NaN()))
+	}, `"NaN"`)
+
+	testMarshal(t, func(s *MarshalState) {
+		s.WriteFloat64(math.NaN())
+	}, `"NaN"`)
+
+	testMarshal(t, func(s *MarshalState) {
+		s.WriteFloat32(float32(math.Inf(-1)))
+	}, `"-Infinity"`)
+
+	testMarshal(t, func(s *MarshalState) {
+		s.WriteFloat64(math.Inf(-1))
+	}, `"-Infinity"`)
+
+	testMarshal(t, func(s *MarshalState) {
+		s.WriteFloat32(float32(math.Inf(1)))
+	}, `"Infinity"`)
+
+	testMarshal(t, func(s *MarshalState) {
+		s.WriteFloat64(math.Inf(1))
+	}, `"Infinity"`)
 
 	// int
 


### PR DESCRIPTION
This PR updates the float32 and float64 marshalers to write `-Infinity`, `Infinity` and `NaN` as strings instead of having the jsoniter library error on those.