### PR TITLE
Fix marshaling of WKTs inside google.protobuf.Any

### DIFF
--- a/test/gogo/wkts_test.go
+++ b/test/gogo/wkts_test.go
@@ -255,6 +255,10 @@ var testMessagesWithWKTs = []struct {
 			AnyValues: []*types.Any{
 				mustAny(&MessageWithMarshaler{Message: "hello"}),
 				mustAny(&MessageWithoutMarshaler{Message: "hello"}),
+				mustAny(mustTimestamp(testTime)),
+				mustAny(mustDuration(testDuration)),
+				mustAny(&types.FieldMask{Paths: []string{"foo.bar", "bar", "baz.qux"}}),
+				mustAny(&types.Value{Kind: &types.Value_StringValue{StringValue: "foo"}}),
 			},
 		},
 		expected: `{
@@ -334,6 +338,22 @@ var testMessagesWithWKTs = []struct {
 				{
 					"@type": "type.googleapis.com/thethings.json.test.MessageWithoutMarshaler",
 					"message": "hello"
+				},
+				{
+					"@type":"type.googleapis.com/google.protobuf.Timestamp",
+					"value":"2006-01-02T08:04:05.123456789Z"
+				},
+				{
+					"@type":"type.googleapis.com/google.protobuf.Duration",
+					"value":"3723.123456789s"
+				},
+				{
+					"@type":"type.googleapis.com/google.protobuf.FieldMask",
+					"value": "foo.bar,bar,baz.qux"
+				},
+				{
+					"@type":"type.googleapis.com/google.protobuf.Value",
+					"value":"foo"
 				}
 			]
 		}`,

--- a/test/golang/wkts_test.go
+++ b/test/golang/wkts_test.go
@@ -257,6 +257,10 @@ var testMessagesWithWKTs = []struct {
 			AnyValues: []*anypb.Any{
 				mustAny(&MessageWithMarshaler{Message: "hello"}),
 				mustAny(&MessageWithoutMarshaler{Message: "hello"}),
+				mustAny(mustTimestamp(testTime)),
+				mustAny(mustDuration(testDuration)),
+				mustAny(&fieldmaskpb.FieldMask{Paths: []string{"foo.bar", "bar", "baz.qux"}}),
+				mustAny(&structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "foo"}}),
 			},
 		},
 		expected: `{
@@ -336,6 +340,22 @@ var testMessagesWithWKTs = []struct {
 				{
 					"@type": "type.googleapis.com/thethings.json.test.MessageWithoutMarshaler",
 					"message": "hello"
+				},
+				{
+					"@type":"type.googleapis.com/google.protobuf.Timestamp",
+					"value":"2006-01-02T08:04:05.123456789Z"
+				},
+				{
+					"@type":"type.googleapis.com/google.protobuf.Duration",
+					"value":"3723.123456789s"
+				},
+				{
+					"@type":"type.googleapis.com/google.protobuf.FieldMask",
+					"value": "foo.bar,bar,baz.qux"
+				},
+				{
+					"@type":"type.googleapis.com/google.protobuf.Value",
+					"value":"foo"
 				}
 			]
 		}`,


### PR DESCRIPTION
This pull request makes sure that supported WKTs wrapped inside google.protobuf.Any are marshaled/unmarshaled by the internal `gogo` and `golang` packages, instead of the external ones.

For unsupported WKTs we delegate unmarshaling the entire Any to the external package, instead of only unmarshaling the value.