### PR TITLE
Fix unmarshaling of field mask objects

### DIFF
--- a/gogo/gogo.go
+++ b/gogo/gogo.go
@@ -240,6 +240,11 @@ func UnmarshalAny(s *jsonplugin.UnmarshalState) *types.Any {
 		return nil
 	}
 
+	if field := sub.ReadObjectField(); field != "" {
+		s.SetErrorf("unexpected %q field in Any", field)
+		return nil
+	}
+
 	// Wrap the unmarshaled message in an Any and return that.
 	v, err := types.MarshalAny(msg)
 	if err != nil {

--- a/golang/golang.go
+++ b/golang/golang.go
@@ -236,6 +236,11 @@ func UnmarshalAny(s *jsonplugin.UnmarshalState) *anypb.Any {
 		return nil
 	}
 
+	if field := sub.ReadObjectField(); field != "" {
+		s.SetErrorf("unexpected %q field in Any", field)
+		return nil
+	}
+
 	// Wrap the unmarshaled message in an Any and return that.
 	v, err := anypb.New(msg)
 	if err != nil {

--- a/jsonplugin/unmarshal_test.go
+++ b/jsonplugin/unmarshal_test.go
@@ -238,4 +238,14 @@ func TestUnmarshaler(t *testing.T) {
 	testUnmarshal(t, func(s *UnmarshalState) interface{} {
 		return s.ReadDuration()
 	}, `"3723s"`, testDuration.Truncate(1000000000))
+
+	// field mask
+
+	testUnmarshal(t, func(s *UnmarshalState) interface{} {
+		return s.ReadFieldMask().GetPaths()
+	}, `"foo,bar,baz.qux"`, []string{"foo", "bar", "baz.qux"})
+
+	testUnmarshal(t, func(s *UnmarshalState) interface{} {
+		return s.ReadFieldMask().GetPaths()
+	}, `{"paths":["foo","bar","baz.qux"]}`, []string{"foo", "bar", "baz.qux"})
 }


### PR DESCRIPTION
This pull request makes sure that when reading a limited number of fields from objects, we ensure that we've read the entire object. This fixes an issue where unmarshaling the object variant of field masks could result in a too early finish of the unmarshaler.

This should fix the failing test in https://github.com/TheThingsNetwork/lorawan-stack/pull/4903.