### PR TITLE
Fix unmarshaling of explicit null maps, slices and messages

### DIFF
--- a/test/gogo/enums_json.pb.go
+++ b/test/gogo/enums_json.pb.go
@@ -173,6 +173,10 @@ func (x *MessageWithEnums) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.Regular = RegularEnum(s.ReadEnum(RegularEnum_value))
 		case "regulars":
 			s.AddField("regulars")
+			if s.ReadNil() {
+				x.Regulars = nil
+				return
+			}
 			s.ReadArray(func() {
 				x.Regulars = append(x.Regulars, RegularEnum(s.ReadEnum(RegularEnum_value)))
 			})
@@ -181,6 +185,10 @@ func (x *MessageWithEnums) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.Custom.UnmarshalProtoJSON(s)
 		case "customs":
 			s.AddField("customs")
+			if s.ReadNil() {
+				x.Customs = nil
+				return
+			}
 			s.ReadArray(func() {
 				var v CustomEnum
 				v.UnmarshalProtoJSON(s)
@@ -188,12 +196,18 @@ func (x *MessageWithEnums) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "wrapped_custom", "wrappedCustom":
 			s.AddField("wrapped_custom")
-			if !s.ReadNil() {
-				x.WrappedCustom = &CustomEnumValue{}
-				x.WrappedCustom.UnmarshalProtoJSON(s.WithField("wrapped_custom", false))
+			if s.ReadNil() {
+				x.WrappedCustom = nil
+				return
 			}
+			x.WrappedCustom = &CustomEnumValue{}
+			x.WrappedCustom.UnmarshalProtoJSON(s.WithField("wrapped_custom", false))
 		case "wrapped_customs", "wrappedCustoms":
 			s.AddField("wrapped_customs")
+			if s.ReadNil() {
+				x.WrappedCustoms = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.WrappedCustoms = append(x.WrappedCustoms, nil)
@@ -259,21 +273,23 @@ func (x *MessageWithOneofEnums) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState)
 		case "regular":
 			s.AddField("regular")
 			ov := &MessageWithOneofEnums_Regular{}
-			ov.Regular = RegularEnum(s.ReadEnum(RegularEnum_value))
 			x.Value = ov
+			ov.Regular = RegularEnum(s.ReadEnum(RegularEnum_value))
 		case "custom":
 			s.AddField("custom")
 			ov := &MessageWithOneofEnums_Custom{}
-			ov.Custom.UnmarshalProtoJSON(s)
 			x.Value = ov
+			ov.Custom.UnmarshalProtoJSON(s)
 		case "wrapped_custom", "wrappedCustom":
 			s.AddField("wrapped_custom")
 			ov := &MessageWithOneofEnums_WrappedCustom{}
-			if !s.ReadNil() {
-				ov.WrappedCustom = &CustomEnumValue{}
-				ov.WrappedCustom.UnmarshalProtoJSON(s.WithField("wrapped_custom", false))
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.WrappedCustom = nil
+				return
+			}
+			ov.WrappedCustom = &CustomEnumValue{}
+			ov.WrappedCustom.UnmarshalProtoJSON(s.WithField("wrapped_custom", false))
 		}
 	})
 }

--- a/test/gogo/gogo_json.pb.go
+++ b/test/gogo/gogo_json.pb.go
@@ -96,15 +96,21 @@ func (x *MessageWithGoGoOptions) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState
 			x.EUIWithCustomName = s.ReadBytes()
 		case "eui_with_custom_name_and_type", "euiWithCustomNameAndType":
 			s.AddField("eui_with_custom_name_and_type")
-			if !s.ReadNil() {
-				x.EUIWithCustomNameAndType = &types.EUI64{}
-				x.EUIWithCustomNameAndType.UnmarshalProtoJSON(s.WithField("eui_with_custom_name_and_type", false))
+			if s.ReadNil() {
+				x.EUIWithCustomNameAndType = nil
+				return
 			}
+			x.EUIWithCustomNameAndType = &types.EUI64{}
+			x.EUIWithCustomNameAndType.UnmarshalProtoJSON(s.WithField("eui_with_custom_name_and_type", false))
 		case "non_nullable_eui_with_custom_name_and_type", "nonNullableEuiWithCustomNameAndType":
 			s.AddField("non_nullable_eui_with_custom_name_and_type")
 			x.NonNullableEUIWithCustomNameAndType.UnmarshalProtoJSON(s.WithField("non_nullable_eui_with_custom_name_and_type", false))
 		case "euis_with_custom_name_and_type", "euisWithCustomNameAndType":
 			s.AddField("euis_with_custom_name_and_type")
+			if s.ReadNil() {
+				x.EUIsWithCustomNameAndType = nil
+				return
+			}
 			s.ReadArray(func() {
 				var v types.EUI64
 				v.UnmarshalProtoJSON(s.WithField("euis_with_custom_name_and_type", false))
@@ -112,6 +118,10 @@ func (x *MessageWithGoGoOptions) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState
 			})
 		case "duration":
 			s.AddField("duration")
+			if s.ReadNil() {
+				x.Duration = nil
+				return
+			}
 			v := s.ReadDuration()
 			if s.Err() != nil {
 				return
@@ -126,6 +136,10 @@ func (x *MessageWithGoGoOptions) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState
 			x.NonNullableDuration = *v
 		case "timestamp":
 			s.AddField("timestamp")
+			if s.ReadNil() {
+				x.Timestamp = nil
+				return
+			}
 			v := s.ReadTime()
 			if s.Err() != nil {
 				return
@@ -249,11 +263,13 @@ func (x *MessageWithNullable) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 		default:
 			s.ReadAny() // ignore unknown field
 		case "sub":
-			if !s.ReadNil() {
-				x.Sub.UnmarshalProtoJSON(s.WithField("sub", true))
-			}
+			x.Sub.UnmarshalProtoJSON(s.WithField("sub", true))
 		case "subs":
 			s.AddField("subs")
+			if s.ReadNil() {
+				x.Subs = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := SubMessage{}
 				v.UnmarshalProtoJSON(s.WithField("subs", false))
@@ -270,6 +286,10 @@ func (x *MessageWithNullable) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.OtherSub = v
 		case "other_subs", "otherSubs":
 			s.AddField("other_subs")
+			if s.ReadNil() {
+				x.OtherSubs = nil
+				return
+			}
 			s.ReadArray(func() {
 				// NOTE: SubMessageWithoutMarshalers does not seem to implement UnmarshalProtoJSON.
 				var v SubMessageWithoutMarshalers
@@ -322,12 +342,18 @@ func (x *MessageWithEmbedded) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 		default:
 			s.ReadAny() // ignore unknown field
 		case "sub":
-			if !s.ReadNil() {
-				x.SubMessage = &SubMessage{}
-				x.SubMessage.UnmarshalProtoJSON(s.WithField("sub", true))
+			if s.ReadNil() {
+				x.SubMessage = nil
+				return
 			}
+			x.SubMessage = &SubMessage{}
+			x.SubMessage.UnmarshalProtoJSON(s.WithField("sub", true))
 		case "other_sub", "otherSub":
 			s.AddField("other_sub")
+			if s.ReadNil() {
+				x.SubMessageWithoutMarshalers = nil
+				return
+			}
 			// NOTE: SubMessageWithoutMarshalers does not seem to implement UnmarshalProtoJSON.
 			var v SubMessageWithoutMarshalers
 			gogo.UnmarshalMessage(s, &v)
@@ -378,9 +404,7 @@ func (x *MessageWithNullableEmbedded) UnmarshalProtoJSON(s *jsonplugin.Unmarshal
 		default:
 			s.ReadAny() // ignore unknown field
 		case "sub":
-			if !s.ReadNil() {
-				x.SubMessage.UnmarshalProtoJSON(s.WithField("sub", true))
-			}
+			x.SubMessage.UnmarshalProtoJSON(s.WithField("sub", true))
 		case "other_sub", "otherSub":
 			s.AddField("other_sub")
 			// NOTE: SubMessageWithoutMarshalers does not seem to implement UnmarshalProtoJSON.

--- a/test/gogo/scalars_json.pb.go
+++ b/test/gogo/scalars_json.pb.go
@@ -201,96 +201,160 @@ func (x *MessageWithScalars) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.DoubleValue = s.ReadFloat64()
 		case "double_values", "doubleValues":
 			s.AddField("double_values")
+			if s.ReadNil() {
+				x.DoubleValues = nil
+				return
+			}
 			x.DoubleValues = s.ReadFloat64Array()
 		case "float_value", "floatValue":
 			s.AddField("float_value")
 			x.FloatValue = s.ReadFloat32()
 		case "float_values", "floatValues":
 			s.AddField("float_values")
+			if s.ReadNil() {
+				x.FloatValues = nil
+				return
+			}
 			x.FloatValues = s.ReadFloat32Array()
 		case "int32_value", "int32Value":
 			s.AddField("int32_value")
 			x.Int32Value = s.ReadInt32()
 		case "int32_values", "int32Values":
 			s.AddField("int32_values")
+			if s.ReadNil() {
+				x.Int32Values = nil
+				return
+			}
 			x.Int32Values = s.ReadInt32Array()
 		case "int64_value", "int64Value":
 			s.AddField("int64_value")
 			x.Int64Value = s.ReadInt64()
 		case "int64_values", "int64Values":
 			s.AddField("int64_values")
+			if s.ReadNil() {
+				x.Int64Values = nil
+				return
+			}
 			x.Int64Values = s.ReadInt64Array()
 		case "uint32_value", "uint32Value":
 			s.AddField("uint32_value")
 			x.Uint32Value = s.ReadUint32()
 		case "uint32_values", "uint32Values":
 			s.AddField("uint32_values")
+			if s.ReadNil() {
+				x.Uint32Values = nil
+				return
+			}
 			x.Uint32Values = s.ReadUint32Array()
 		case "uint64_value", "uint64Value":
 			s.AddField("uint64_value")
 			x.Uint64Value = s.ReadUint64()
 		case "uint64_values", "uint64Values":
 			s.AddField("uint64_values")
+			if s.ReadNil() {
+				x.Uint64Values = nil
+				return
+			}
 			x.Uint64Values = s.ReadUint64Array()
 		case "sint32_value", "sint32Value":
 			s.AddField("sint32_value")
 			x.Sint32Value = s.ReadInt32()
 		case "sint32_values", "sint32Values":
 			s.AddField("sint32_values")
+			if s.ReadNil() {
+				x.Sint32Values = nil
+				return
+			}
 			x.Sint32Values = s.ReadInt32Array()
 		case "sint64_value", "sint64Value":
 			s.AddField("sint64_value")
 			x.Sint64Value = s.ReadInt64()
 		case "sint64_values", "sint64Values":
 			s.AddField("sint64_values")
+			if s.ReadNil() {
+				x.Sint64Values = nil
+				return
+			}
 			x.Sint64Values = s.ReadInt64Array()
 		case "fixed32_value", "fixed32Value":
 			s.AddField("fixed32_value")
 			x.Fixed32Value = s.ReadUint32()
 		case "fixed32_values", "fixed32Values":
 			s.AddField("fixed32_values")
+			if s.ReadNil() {
+				x.Fixed32Values = nil
+				return
+			}
 			x.Fixed32Values = s.ReadUint32Array()
 		case "fixed64_value", "fixed64Value":
 			s.AddField("fixed64_value")
 			x.Fixed64Value = s.ReadUint64()
 		case "fixed64_values", "fixed64Values":
 			s.AddField("fixed64_values")
+			if s.ReadNil() {
+				x.Fixed64Values = nil
+				return
+			}
 			x.Fixed64Values = s.ReadUint64Array()
 		case "sfixed32_value", "sfixed32Value":
 			s.AddField("sfixed32_value")
 			x.Sfixed32Value = s.ReadInt32()
 		case "sfixed32_values", "sfixed32Values":
 			s.AddField("sfixed32_values")
+			if s.ReadNil() {
+				x.Sfixed32Values = nil
+				return
+			}
 			x.Sfixed32Values = s.ReadInt32Array()
 		case "sfixed64_value", "sfixed64Value":
 			s.AddField("sfixed64_value")
 			x.Sfixed64Value = s.ReadInt64()
 		case "sfixed64_values", "sfixed64Values":
 			s.AddField("sfixed64_values")
+			if s.ReadNil() {
+				x.Sfixed64Values = nil
+				return
+			}
 			x.Sfixed64Values = s.ReadInt64Array()
 		case "bool_value", "boolValue":
 			s.AddField("bool_value")
 			x.BoolValue = s.ReadBool()
 		case "bool_values", "boolValues":
 			s.AddField("bool_values")
+			if s.ReadNil() {
+				x.BoolValues = nil
+				return
+			}
 			x.BoolValues = s.ReadBoolArray()
 		case "string_value", "stringValue":
 			s.AddField("string_value")
 			x.StringValue = s.ReadString()
 		case "string_values", "stringValues":
 			s.AddField("string_values")
+			if s.ReadNil() {
+				x.StringValues = nil
+				return
+			}
 			x.StringValues = s.ReadStringArray()
 		case "bytes_value", "bytesValue":
 			s.AddField("bytes_value")
 			x.BytesValue = s.ReadBytes()
 		case "bytes_values", "bytesValues":
 			s.AddField("bytes_values")
+			if s.ReadNil() {
+				x.BytesValues = nil
+				return
+			}
 			x.BytesValues = s.ReadBytesArray()
 		case "hex_bytes_value", "hexBytesValue":
 			s.AddField("hex_bytes_value")
 			x.HexBytesValue = types.UnmarshalHEX(s.WithField("hex_bytes_value", false))
 		case "hex_bytes_values", "hexBytesValues":
 			s.AddField("hex_bytes_values")
+			if s.ReadNil() {
+				x.HexBytesValues = nil
+				return
+			}
 			x.HexBytesValues = types.UnmarshalHEXArray(s.WithField("hex_bytes_values", false))
 		}
 	})
@@ -397,83 +461,83 @@ func (x *MessageWithOneofScalars) UnmarshalProtoJSON(s *jsonplugin.UnmarshalStat
 		case "double_value", "doubleValue":
 			s.AddField("double_value")
 			ov := &MessageWithOneofScalars_DoubleValue{}
-			ov.DoubleValue = s.ReadFloat64()
 			x.Value = ov
+			ov.DoubleValue = s.ReadFloat64()
 		case "float_value", "floatValue":
 			s.AddField("float_value")
 			ov := &MessageWithOneofScalars_FloatValue{}
-			ov.FloatValue = s.ReadFloat32()
 			x.Value = ov
+			ov.FloatValue = s.ReadFloat32()
 		case "int32_value", "int32Value":
 			s.AddField("int32_value")
 			ov := &MessageWithOneofScalars_Int32Value{}
-			ov.Int32Value = s.ReadInt32()
 			x.Value = ov
+			ov.Int32Value = s.ReadInt32()
 		case "int64_value", "int64Value":
 			s.AddField("int64_value")
 			ov := &MessageWithOneofScalars_Int64Value{}
-			ov.Int64Value = s.ReadInt64()
 			x.Value = ov
+			ov.Int64Value = s.ReadInt64()
 		case "uint32_value", "uint32Value":
 			s.AddField("uint32_value")
 			ov := &MessageWithOneofScalars_Uint32Value{}
-			ov.Uint32Value = s.ReadUint32()
 			x.Value = ov
+			ov.Uint32Value = s.ReadUint32()
 		case "uint64_value", "uint64Value":
 			s.AddField("uint64_value")
 			ov := &MessageWithOneofScalars_Uint64Value{}
-			ov.Uint64Value = s.ReadUint64()
 			x.Value = ov
+			ov.Uint64Value = s.ReadUint64()
 		case "sint32_value", "sint32Value":
 			s.AddField("sint32_value")
 			ov := &MessageWithOneofScalars_Sint32Value{}
-			ov.Sint32Value = s.ReadInt32()
 			x.Value = ov
+			ov.Sint32Value = s.ReadInt32()
 		case "sint64_value", "sint64Value":
 			s.AddField("sint64_value")
 			ov := &MessageWithOneofScalars_Sint64Value{}
-			ov.Sint64Value = s.ReadInt64()
 			x.Value = ov
+			ov.Sint64Value = s.ReadInt64()
 		case "fixed32_value", "fixed32Value":
 			s.AddField("fixed32_value")
 			ov := &MessageWithOneofScalars_Fixed32Value{}
-			ov.Fixed32Value = s.ReadUint32()
 			x.Value = ov
+			ov.Fixed32Value = s.ReadUint32()
 		case "fixed64_value", "fixed64Value":
 			s.AddField("fixed64_value")
 			ov := &MessageWithOneofScalars_Fixed64Value{}
-			ov.Fixed64Value = s.ReadUint64()
 			x.Value = ov
+			ov.Fixed64Value = s.ReadUint64()
 		case "sfixed32_value", "sfixed32Value":
 			s.AddField("sfixed32_value")
 			ov := &MessageWithOneofScalars_Sfixed32Value{}
-			ov.Sfixed32Value = s.ReadInt32()
 			x.Value = ov
+			ov.Sfixed32Value = s.ReadInt32()
 		case "sfixed64_value", "sfixed64Value":
 			s.AddField("sfixed64_value")
 			ov := &MessageWithOneofScalars_Sfixed64Value{}
-			ov.Sfixed64Value = s.ReadInt64()
 			x.Value = ov
+			ov.Sfixed64Value = s.ReadInt64()
 		case "bool_value", "boolValue":
 			s.AddField("bool_value")
 			ov := &MessageWithOneofScalars_BoolValue{}
-			ov.BoolValue = s.ReadBool()
 			x.Value = ov
+			ov.BoolValue = s.ReadBool()
 		case "string_value", "stringValue":
 			s.AddField("string_value")
 			ov := &MessageWithOneofScalars_StringValue{}
-			ov.StringValue = s.ReadString()
 			x.Value = ov
+			ov.StringValue = s.ReadString()
 		case "bytes_value", "bytesValue":
 			s.AddField("bytes_value")
 			ov := &MessageWithOneofScalars_BytesValue{}
-			ov.BytesValue = s.ReadBytes()
 			x.Value = ov
+			ov.BytesValue = s.ReadBytes()
 		case "hex_bytes_value", "hexBytesValue":
 			s.AddField("hex_bytes_value")
 			ov := &MessageWithOneofScalars_HexBytesValue{}
-			ov.HexBytesValue = types.UnmarshalHEX(s.WithField("hex_bytes_value", false))
 			x.Value = ov
+			ov.HexBytesValue = types.UnmarshalHEX(s.WithField("hex_bytes_value", false))
 		}
 	})
 }
@@ -827,162 +891,270 @@ func (x *MessageWithScalarMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState)
 			s.ReadAny() // ignore unknown field
 		case "string_double_map", "stringDoubleMap":
 			s.AddField("string_double_map")
+			if s.ReadNil() {
+				x.StringDoubleMap = nil
+				return
+			}
 			x.StringDoubleMap = make(map[string]float64)
 			s.ReadStringMap(func(key string) {
 				x.StringDoubleMap[key] = s.ReadFloat64()
 			})
 		case "string_float_map", "stringFloatMap":
 			s.AddField("string_float_map")
+			if s.ReadNil() {
+				x.StringFloatMap = nil
+				return
+			}
 			x.StringFloatMap = make(map[string]float32)
 			s.ReadStringMap(func(key string) {
 				x.StringFloatMap[key] = s.ReadFloat32()
 			})
 		case "string_int32_map", "stringInt32Map":
 			s.AddField("string_int32_map")
+			if s.ReadNil() {
+				x.StringInt32Map = nil
+				return
+			}
 			x.StringInt32Map = make(map[string]int32)
 			s.ReadStringMap(func(key string) {
 				x.StringInt32Map[key] = s.ReadInt32()
 			})
 		case "int32_string_map", "int32StringMap":
 			s.AddField("int32_string_map")
+			if s.ReadNil() {
+				x.Int32StringMap = nil
+				return
+			}
 			x.Int32StringMap = make(map[int32]string)
 			s.ReadInt32Map(func(key int32) {
 				x.Int32StringMap[key] = s.ReadString()
 			})
 		case "string_int64_map", "stringInt64Map":
 			s.AddField("string_int64_map")
+			if s.ReadNil() {
+				x.StringInt64Map = nil
+				return
+			}
 			x.StringInt64Map = make(map[string]int64)
 			s.ReadStringMap(func(key string) {
 				x.StringInt64Map[key] = s.ReadInt64()
 			})
 		case "int64_string_map", "int64StringMap":
 			s.AddField("int64_string_map")
+			if s.ReadNil() {
+				x.Int64StringMap = nil
+				return
+			}
 			x.Int64StringMap = make(map[int64]string)
 			s.ReadInt64Map(func(key int64) {
 				x.Int64StringMap[key] = s.ReadString()
 			})
 		case "string_uint32_map", "stringUint32Map":
 			s.AddField("string_uint32_map")
+			if s.ReadNil() {
+				x.StringUint32Map = nil
+				return
+			}
 			x.StringUint32Map = make(map[string]uint32)
 			s.ReadStringMap(func(key string) {
 				x.StringUint32Map[key] = s.ReadUint32()
 			})
 		case "uint32_string_map", "uint32StringMap":
 			s.AddField("uint32_string_map")
+			if s.ReadNil() {
+				x.Uint32StringMap = nil
+				return
+			}
 			x.Uint32StringMap = make(map[uint32]string)
 			s.ReadUint32Map(func(key uint32) {
 				x.Uint32StringMap[key] = s.ReadString()
 			})
 		case "string_uint64_map", "stringUint64Map":
 			s.AddField("string_uint64_map")
+			if s.ReadNil() {
+				x.StringUint64Map = nil
+				return
+			}
 			x.StringUint64Map = make(map[string]uint64)
 			s.ReadStringMap(func(key string) {
 				x.StringUint64Map[key] = s.ReadUint64()
 			})
 		case "uint64_string_map", "uint64StringMap":
 			s.AddField("uint64_string_map")
+			if s.ReadNil() {
+				x.Uint64StringMap = nil
+				return
+			}
 			x.Uint64StringMap = make(map[uint64]string)
 			s.ReadUint64Map(func(key uint64) {
 				x.Uint64StringMap[key] = s.ReadString()
 			})
 		case "string_sint32_map", "stringSint32Map":
 			s.AddField("string_sint32_map")
+			if s.ReadNil() {
+				x.StringSint32Map = nil
+				return
+			}
 			x.StringSint32Map = make(map[string]int32)
 			s.ReadStringMap(func(key string) {
 				x.StringSint32Map[key] = s.ReadInt32()
 			})
 		case "sint32_string_map", "sint32StringMap":
 			s.AddField("sint32_string_map")
+			if s.ReadNil() {
+				x.Sint32StringMap = nil
+				return
+			}
 			x.Sint32StringMap = make(map[int32]string)
 			s.ReadInt32Map(func(key int32) {
 				x.Sint32StringMap[key] = s.ReadString()
 			})
 		case "string_sint64_map", "stringSint64Map":
 			s.AddField("string_sint64_map")
+			if s.ReadNil() {
+				x.StringSint64Map = nil
+				return
+			}
 			x.StringSint64Map = make(map[string]int64)
 			s.ReadStringMap(func(key string) {
 				x.StringSint64Map[key] = s.ReadInt64()
 			})
 		case "sint64_string_map", "sint64StringMap":
 			s.AddField("sint64_string_map")
+			if s.ReadNil() {
+				x.Sint64StringMap = nil
+				return
+			}
 			x.Sint64StringMap = make(map[int64]string)
 			s.ReadInt64Map(func(key int64) {
 				x.Sint64StringMap[key] = s.ReadString()
 			})
 		case "string_fixed32_map", "stringFixed32Map":
 			s.AddField("string_fixed32_map")
+			if s.ReadNil() {
+				x.StringFixed32Map = nil
+				return
+			}
 			x.StringFixed32Map = make(map[string]uint32)
 			s.ReadStringMap(func(key string) {
 				x.StringFixed32Map[key] = s.ReadUint32()
 			})
 		case "fixed32_string_map", "fixed32StringMap":
 			s.AddField("fixed32_string_map")
+			if s.ReadNil() {
+				x.Fixed32StringMap = nil
+				return
+			}
 			x.Fixed32StringMap = make(map[uint32]string)
 			s.ReadUint32Map(func(key uint32) {
 				x.Fixed32StringMap[key] = s.ReadString()
 			})
 		case "string_fixed64_map", "stringFixed64Map":
 			s.AddField("string_fixed64_map")
+			if s.ReadNil() {
+				x.StringFixed64Map = nil
+				return
+			}
 			x.StringFixed64Map = make(map[string]uint64)
 			s.ReadStringMap(func(key string) {
 				x.StringFixed64Map[key] = s.ReadUint64()
 			})
 		case "fixed64_string_map", "fixed64StringMap":
 			s.AddField("fixed64_string_map")
+			if s.ReadNil() {
+				x.Fixed64StringMap = nil
+				return
+			}
 			x.Fixed64StringMap = make(map[uint64]string)
 			s.ReadUint64Map(func(key uint64) {
 				x.Fixed64StringMap[key] = s.ReadString()
 			})
 		case "string_sfixed32_map", "stringSfixed32Map":
 			s.AddField("string_sfixed32_map")
+			if s.ReadNil() {
+				x.StringSfixed32Map = nil
+				return
+			}
 			x.StringSfixed32Map = make(map[string]int32)
 			s.ReadStringMap(func(key string) {
 				x.StringSfixed32Map[key] = s.ReadInt32()
 			})
 		case "sfixed32_string_map", "sfixed32StringMap":
 			s.AddField("sfixed32_string_map")
+			if s.ReadNil() {
+				x.Sfixed32StringMap = nil
+				return
+			}
 			x.Sfixed32StringMap = make(map[int32]string)
 			s.ReadInt32Map(func(key int32) {
 				x.Sfixed32StringMap[key] = s.ReadString()
 			})
 		case "string_sfixed64_map", "stringSfixed64Map":
 			s.AddField("string_sfixed64_map")
+			if s.ReadNil() {
+				x.StringSfixed64Map = nil
+				return
+			}
 			x.StringSfixed64Map = make(map[string]int64)
 			s.ReadStringMap(func(key string) {
 				x.StringSfixed64Map[key] = s.ReadInt64()
 			})
 		case "sfixed64_string_map", "sfixed64StringMap":
 			s.AddField("sfixed64_string_map")
+			if s.ReadNil() {
+				x.Sfixed64StringMap = nil
+				return
+			}
 			x.Sfixed64StringMap = make(map[int64]string)
 			s.ReadInt64Map(func(key int64) {
 				x.Sfixed64StringMap[key] = s.ReadString()
 			})
 		case "string_bool_map", "stringBoolMap":
 			s.AddField("string_bool_map")
+			if s.ReadNil() {
+				x.StringBoolMap = nil
+				return
+			}
 			x.StringBoolMap = make(map[string]bool)
 			s.ReadStringMap(func(key string) {
 				x.StringBoolMap[key] = s.ReadBool()
 			})
 		case "bool_string_map", "boolStringMap":
 			s.AddField("bool_string_map")
+			if s.ReadNil() {
+				x.BoolStringMap = nil
+				return
+			}
 			x.BoolStringMap = make(map[bool]string)
 			s.ReadBoolMap(func(key bool) {
 				x.BoolStringMap[key] = s.ReadString()
 			})
 		case "string_string_map", "stringStringMap":
 			s.AddField("string_string_map")
+			if s.ReadNil() {
+				x.StringStringMap = nil
+				return
+			}
 			x.StringStringMap = make(map[string]string)
 			s.ReadStringMap(func(key string) {
 				x.StringStringMap[key] = s.ReadString()
 			})
 		case "string_bytes_map", "stringBytesMap":
 			s.AddField("string_bytes_map")
+			if s.ReadNil() {
+				x.StringBytesMap = nil
+				return
+			}
 			x.StringBytesMap = make(map[string][]byte)
 			s.ReadStringMap(func(key string) {
 				x.StringBytesMap[key] = s.ReadBytes()
 			})
 		case "string_hex_bytes_map", "stringHexBytesMap":
 			s.AddField("string_hex_bytes_map")
+			if s.ReadNil() {
+				x.StringHexBytesMap = nil
+				return
+			}
 			x.StringHexBytesMap = types.UnmarshalStringHEXMap(s.WithField("string_hex_bytes_map", false))
 		}
 	})

--- a/test/gogo/wkts_json.pb.go
+++ b/test/gogo/wkts_json.pb.go
@@ -489,15 +489,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			s.ReadAny() // ignore unknown field
 		case "double_value", "doubleValue":
 			s.AddField("double_value")
-			if !s.ReadNil() {
-				v := s.ReadFloat64()
-				if s.Err() != nil {
-					return
-				}
-				x.DoubleValue = &types.DoubleValue{Value: v}
+			if s.ReadNil() {
+				x.DoubleValue = nil
+				return
 			}
+			v := s.ReadFloat64()
+			if s.Err() != nil {
+				return
+			}
+			x.DoubleValue = &types.DoubleValue{Value: v}
 		case "double_values", "doubleValues":
 			s.AddField("double_values")
+			if s.ReadNil() {
+				x.DoubleValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.DoubleValues = append(x.DoubleValues, nil)
@@ -511,15 +517,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "float_value", "floatValue":
 			s.AddField("float_value")
-			if !s.ReadNil() {
-				v := s.ReadFloat32()
-				if s.Err() != nil {
-					return
-				}
-				x.FloatValue = &types.FloatValue{Value: v}
+			if s.ReadNil() {
+				x.FloatValue = nil
+				return
 			}
+			v := s.ReadFloat32()
+			if s.Err() != nil {
+				return
+			}
+			x.FloatValue = &types.FloatValue{Value: v}
 		case "float_values", "floatValues":
 			s.AddField("float_values")
+			if s.ReadNil() {
+				x.FloatValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.FloatValues = append(x.FloatValues, nil)
@@ -533,15 +545,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "int32_value", "int32Value":
 			s.AddField("int32_value")
-			if !s.ReadNil() {
-				v := s.ReadInt32()
-				if s.Err() != nil {
-					return
-				}
-				x.Int32Value = &types.Int32Value{Value: v}
+			if s.ReadNil() {
+				x.Int32Value = nil
+				return
 			}
+			v := s.ReadInt32()
+			if s.Err() != nil {
+				return
+			}
+			x.Int32Value = &types.Int32Value{Value: v}
 		case "int32_values", "int32Values":
 			s.AddField("int32_values")
+			if s.ReadNil() {
+				x.Int32Values = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.Int32Values = append(x.Int32Values, nil)
@@ -555,15 +573,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "int64_value", "int64Value":
 			s.AddField("int64_value")
-			if !s.ReadNil() {
-				v := s.ReadInt64()
-				if s.Err() != nil {
-					return
-				}
-				x.Int64Value = &types.Int64Value{Value: v}
+			if s.ReadNil() {
+				x.Int64Value = nil
+				return
 			}
+			v := s.ReadInt64()
+			if s.Err() != nil {
+				return
+			}
+			x.Int64Value = &types.Int64Value{Value: v}
 		case "int64_values", "int64Values":
 			s.AddField("int64_values")
+			if s.ReadNil() {
+				x.Int64Values = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.Int64Values = append(x.Int64Values, nil)
@@ -577,15 +601,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "uint32_value", "uint32Value":
 			s.AddField("uint32_value")
-			if !s.ReadNil() {
-				v := s.ReadUint32()
-				if s.Err() != nil {
-					return
-				}
-				x.Uint32Value = &types.UInt32Value{Value: v}
+			if s.ReadNil() {
+				x.Uint32Value = nil
+				return
 			}
+			v := s.ReadUint32()
+			if s.Err() != nil {
+				return
+			}
+			x.Uint32Value = &types.UInt32Value{Value: v}
 		case "uint32_values", "uint32Values":
 			s.AddField("uint32_values")
+			if s.ReadNil() {
+				x.Uint32Values = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.Uint32Values = append(x.Uint32Values, nil)
@@ -599,15 +629,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "uint64_value", "uint64Value":
 			s.AddField("uint64_value")
-			if !s.ReadNil() {
-				v := s.ReadUint64()
-				if s.Err() != nil {
-					return
-				}
-				x.Uint64Value = &types.UInt64Value{Value: v}
+			if s.ReadNil() {
+				x.Uint64Value = nil
+				return
 			}
+			v := s.ReadUint64()
+			if s.Err() != nil {
+				return
+			}
+			x.Uint64Value = &types.UInt64Value{Value: v}
 		case "uint64_values", "uint64Values":
 			s.AddField("uint64_values")
+			if s.ReadNil() {
+				x.Uint64Values = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.Uint64Values = append(x.Uint64Values, nil)
@@ -621,15 +657,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "bool_value", "boolValue":
 			s.AddField("bool_value")
-			if !s.ReadNil() {
-				v := s.ReadBool()
-				if s.Err() != nil {
-					return
-				}
-				x.BoolValue = &types.BoolValue{Value: v}
+			if s.ReadNil() {
+				x.BoolValue = nil
+				return
 			}
+			v := s.ReadBool()
+			if s.Err() != nil {
+				return
+			}
+			x.BoolValue = &types.BoolValue{Value: v}
 		case "bool_values", "boolValues":
 			s.AddField("bool_values")
+			if s.ReadNil() {
+				x.BoolValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.BoolValues = append(x.BoolValues, nil)
@@ -643,15 +685,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_value", "stringValue":
 			s.AddField("string_value")
-			if !s.ReadNil() {
-				v := s.ReadString()
-				if s.Err() != nil {
-					return
-				}
-				x.StringValue = &types.StringValue{Value: v}
+			if s.ReadNil() {
+				x.StringValue = nil
+				return
 			}
+			v := s.ReadString()
+			if s.Err() != nil {
+				return
+			}
+			x.StringValue = &types.StringValue{Value: v}
 		case "string_values", "stringValues":
 			s.AddField("string_values")
+			if s.ReadNil() {
+				x.StringValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.StringValues = append(x.StringValues, nil)
@@ -665,15 +713,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "bytes_value", "bytesValue":
 			s.AddField("bytes_value")
-			if !s.ReadNil() {
-				v := s.ReadBytes()
-				if s.Err() != nil {
-					return
-				}
-				x.BytesValue = &types.BytesValue{Value: v}
+			if s.ReadNil() {
+				x.BytesValue = nil
+				return
 			}
+			v := s.ReadBytes()
+			if s.Err() != nil {
+				return
+			}
+			x.BytesValue = &types.BytesValue{Value: v}
 		case "bytes_values", "bytesValues":
 			s.AddField("bytes_values")
+			if s.ReadNil() {
+				x.BytesValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.BytesValues = append(x.BytesValues, nil)
@@ -687,6 +741,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "empty_value", "emptyValue":
 			s.AddField("empty_value")
+			if s.ReadNil() {
+				x.EmptyValue = nil
+				return
+			}
 			v := gogo.UnmarshalEmpty(s)
 			if s.Err() != nil {
 				return
@@ -694,6 +752,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.EmptyValue = v
 		case "empty_values", "emptyValues":
 			s.AddField("empty_values")
+			if s.ReadNil() {
+				x.EmptyValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := gogo.UnmarshalEmpty(s)
 				if s.Err() != nil {
@@ -703,6 +765,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "timestamp_value", "timestampValue":
 			s.AddField("timestamp_value")
+			if s.ReadNil() {
+				x.TimestampValue = nil
+				return
+			}
 			v := gogo.UnmarshalTimestamp(s)
 			if s.Err() != nil {
 				return
@@ -710,6 +776,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.TimestampValue = v
 		case "timestamp_values", "timestampValues":
 			s.AddField("timestamp_values")
+			if s.ReadNil() {
+				x.TimestampValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := gogo.UnmarshalTimestamp(s)
 				if s.Err() != nil {
@@ -719,6 +789,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "duration_value", "durationValue":
 			s.AddField("duration_value")
+			if s.ReadNil() {
+				x.DurationValue = nil
+				return
+			}
 			v := gogo.UnmarshalDuration(s)
 			if s.Err() != nil {
 				return
@@ -726,6 +800,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.DurationValue = v
 		case "duration_values", "durationValues":
 			s.AddField("duration_values")
+			if s.ReadNil() {
+				x.DurationValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := gogo.UnmarshalDuration(s)
 				if s.Err() != nil {
@@ -735,6 +813,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "field_mask_value", "fieldMaskValue":
 			s.AddField("field_mask_value")
+			if s.ReadNil() {
+				x.FieldMaskValue = nil
+				return
+			}
 			v := gogo.UnmarshalFieldMask(s)
 			if s.Err() != nil {
 				return
@@ -742,6 +824,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.FieldMaskValue = v
 		case "field_mask_values", "fieldMaskValues":
 			s.AddField("field_mask_values")
+			if s.ReadNil() {
+				x.FieldMaskValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := gogo.UnmarshalFieldMask(s)
 				if s.Err() != nil {
@@ -751,6 +837,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "value_value", "valueValue":
 			s.AddField("value_value")
+			if s.ReadNil() {
+				x.ValueValue = &types.Value{Kind: &types.Value_NullValue{}}
+				return
+			}
 			v := gogo.UnmarshalValue(s)
 			if s.Err() != nil {
 				return
@@ -758,6 +848,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.ValueValue = v
 		case "value_values", "valueValues":
 			s.AddField("value_values")
+			if s.ReadNil() {
+				x.ValueValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := gogo.UnmarshalValue(s)
 				if s.Err() != nil {
@@ -767,6 +861,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "list_value_value", "listValueValue":
 			s.AddField("list_value_value")
+			if s.ReadNil() {
+				x.ListValueValue = nil
+				return
+			}
 			v := gogo.UnmarshalListValue(s)
 			if s.Err() != nil {
 				return
@@ -774,6 +872,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.ListValueValue = v
 		case "list_value_values", "listValueValues":
 			s.AddField("list_value_values")
+			if s.ReadNil() {
+				x.ListValueValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := gogo.UnmarshalListValue(s)
 				if s.Err() != nil {
@@ -783,6 +885,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "struct_value", "structValue":
 			s.AddField("struct_value")
+			if s.ReadNil() {
+				x.StructValue = nil
+				return
+			}
 			v := gogo.UnmarshalStruct(s)
 			if s.Err() != nil {
 				return
@@ -790,6 +896,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.StructValue = v
 		case "struct_values", "structValues":
 			s.AddField("struct_values")
+			if s.ReadNil() {
+				x.StructValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := gogo.UnmarshalStruct(s)
 				if s.Err() != nil {
@@ -799,6 +909,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "any_value", "anyValue":
 			s.AddField("any_value")
+			if s.ReadNil() {
+				x.AnyValue = nil
+				return
+			}
 			v := gogo.UnmarshalAny(s)
 			if s.Err() != nil {
 				return
@@ -806,6 +920,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.AnyValue = v
 		case "any_values", "anyValues":
 			s.AddField("any_values")
+			if s.ReadNil() {
+				x.AnyValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := gogo.UnmarshalAny(s)
 				if s.Err() != nil {
@@ -990,174 +1108,224 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 		case "double_value", "doubleValue":
 			s.AddField("double_value")
 			ov := &MessageWithOneofWKTs_DoubleValue{}
-			if !s.ReadNil() {
-				v := s.ReadFloat64()
-				if s.Err() != nil {
-					return
-				}
-				ov.DoubleValue = &types.DoubleValue{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.DoubleValue = nil
+				return
+			}
+			v := s.ReadFloat64()
+			if s.Err() != nil {
+				return
+			}
+			ov.DoubleValue = &types.DoubleValue{Value: v}
 		case "float_value", "floatValue":
 			s.AddField("float_value")
 			ov := &MessageWithOneofWKTs_FloatValue{}
-			if !s.ReadNil() {
-				v := s.ReadFloat32()
-				if s.Err() != nil {
-					return
-				}
-				ov.FloatValue = &types.FloatValue{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.FloatValue = nil
+				return
+			}
+			v := s.ReadFloat32()
+			if s.Err() != nil {
+				return
+			}
+			ov.FloatValue = &types.FloatValue{Value: v}
 		case "int32_value", "int32Value":
 			s.AddField("int32_value")
 			ov := &MessageWithOneofWKTs_Int32Value{}
-			if !s.ReadNil() {
-				v := s.ReadInt32()
-				if s.Err() != nil {
-					return
-				}
-				ov.Int32Value = &types.Int32Value{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.Int32Value = nil
+				return
+			}
+			v := s.ReadInt32()
+			if s.Err() != nil {
+				return
+			}
+			ov.Int32Value = &types.Int32Value{Value: v}
 		case "int64_value", "int64Value":
 			s.AddField("int64_value")
 			ov := &MessageWithOneofWKTs_Int64Value{}
-			if !s.ReadNil() {
-				v := s.ReadInt64()
-				if s.Err() != nil {
-					return
-				}
-				ov.Int64Value = &types.Int64Value{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.Int64Value = nil
+				return
+			}
+			v := s.ReadInt64()
+			if s.Err() != nil {
+				return
+			}
+			ov.Int64Value = &types.Int64Value{Value: v}
 		case "uint32_value", "uint32Value":
 			s.AddField("uint32_value")
 			ov := &MessageWithOneofWKTs_Uint32Value{}
-			if !s.ReadNil() {
-				v := s.ReadUint32()
-				if s.Err() != nil {
-					return
-				}
-				ov.Uint32Value = &types.UInt32Value{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.Uint32Value = nil
+				return
+			}
+			v := s.ReadUint32()
+			if s.Err() != nil {
+				return
+			}
+			ov.Uint32Value = &types.UInt32Value{Value: v}
 		case "uint64_value", "uint64Value":
 			s.AddField("uint64_value")
 			ov := &MessageWithOneofWKTs_Uint64Value{}
-			if !s.ReadNil() {
-				v := s.ReadUint64()
-				if s.Err() != nil {
-					return
-				}
-				ov.Uint64Value = &types.UInt64Value{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.Uint64Value = nil
+				return
+			}
+			v := s.ReadUint64()
+			if s.Err() != nil {
+				return
+			}
+			ov.Uint64Value = &types.UInt64Value{Value: v}
 		case "bool_value", "boolValue":
 			s.AddField("bool_value")
 			ov := &MessageWithOneofWKTs_BoolValue{}
-			if !s.ReadNil() {
-				v := s.ReadBool()
-				if s.Err() != nil {
-					return
-				}
-				ov.BoolValue = &types.BoolValue{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.BoolValue = nil
+				return
+			}
+			v := s.ReadBool()
+			if s.Err() != nil {
+				return
+			}
+			ov.BoolValue = &types.BoolValue{Value: v}
 		case "string_value", "stringValue":
 			s.AddField("string_value")
 			ov := &MessageWithOneofWKTs_StringValue{}
-			if !s.ReadNil() {
-				v := s.ReadString()
-				if s.Err() != nil {
-					return
-				}
-				ov.StringValue = &types.StringValue{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.StringValue = nil
+				return
+			}
+			v := s.ReadString()
+			if s.Err() != nil {
+				return
+			}
+			ov.StringValue = &types.StringValue{Value: v}
 		case "bytes_value", "bytesValue":
 			s.AddField("bytes_value")
 			ov := &MessageWithOneofWKTs_BytesValue{}
-			if !s.ReadNil() {
-				v := s.ReadBytes()
-				if s.Err() != nil {
-					return
-				}
-				ov.BytesValue = &types.BytesValue{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.BytesValue = nil
+				return
+			}
+			v := s.ReadBytes()
+			if s.Err() != nil {
+				return
+			}
+			ov.BytesValue = &types.BytesValue{Value: v}
 		case "empty_value", "emptyValue":
 			s.AddField("empty_value")
 			ov := &MessageWithOneofWKTs_EmptyValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.EmptyValue = nil
+				return
+			}
 			v := gogo.UnmarshalEmpty(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.EmptyValue = v
-			x.Value = ov
 		case "timestamp_value", "timestampValue":
 			s.AddField("timestamp_value")
 			ov := &MessageWithOneofWKTs_TimestampValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.TimestampValue = nil
+				return
+			}
 			v := gogo.UnmarshalTimestamp(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.TimestampValue = v
-			x.Value = ov
 		case "duration_value", "durationValue":
 			s.AddField("duration_value")
 			ov := &MessageWithOneofWKTs_DurationValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.DurationValue = nil
+				return
+			}
 			v := gogo.UnmarshalDuration(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.DurationValue = v
-			x.Value = ov
 		case "field_mask_value", "fieldMaskValue":
 			s.AddField("field_mask_value")
 			ov := &MessageWithOneofWKTs_FieldMaskValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.FieldMaskValue = nil
+				return
+			}
 			v := gogo.UnmarshalFieldMask(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.FieldMaskValue = v
-			x.Value = ov
 		case "value_value", "valueValue":
 			s.AddField("value_value")
 			ov := &MessageWithOneofWKTs_ValueValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.ValueValue = &types.Value{Kind: &types.Value_NullValue{}}
+				return
+			}
 			v := gogo.UnmarshalValue(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.ValueValue = v
-			x.Value = ov
 		case "list_value_value", "listValueValue":
 			s.AddField("list_value_value")
 			ov := &MessageWithOneofWKTs_ListValueValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.ListValueValue = nil
+				return
+			}
 			v := gogo.UnmarshalListValue(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.ListValueValue = v
-			x.Value = ov
 		case "struct_value", "structValue":
 			s.AddField("struct_value")
 			ov := &MessageWithOneofWKTs_StructValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.StructValue = nil
+				return
+			}
 			v := gogo.UnmarshalStruct(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.StructValue = v
-			x.Value = ov
 		case "any_value", "anyValue":
 			s.AddField("any_value")
 			ov := &MessageWithOneofWKTs_AnyValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.AnyValue = nil
+				return
+			}
 			v := gogo.UnmarshalAny(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.AnyValue = v
-			x.Value = ov
 		}
 	})
 }
@@ -1466,6 +1634,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			s.ReadAny() // ignore unknown field
 		case "string_double_map", "stringDoubleMap":
 			s.AddField("string_double_map")
+			if s.ReadNil() {
+				x.StringDoubleMap = nil
+				return
+			}
 			x.StringDoubleMap = make(map[string]*types.DoubleValue)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1480,6 +1652,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_float_map", "stringFloatMap":
 			s.AddField("string_float_map")
+			if s.ReadNil() {
+				x.StringFloatMap = nil
+				return
+			}
 			x.StringFloatMap = make(map[string]*types.FloatValue)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1494,6 +1670,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_int32_map", "stringInt32Map":
 			s.AddField("string_int32_map")
+			if s.ReadNil() {
+				x.StringInt32Map = nil
+				return
+			}
 			x.StringInt32Map = make(map[string]*types.Int32Value)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1508,6 +1688,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_int64_map", "stringInt64Map":
 			s.AddField("string_int64_map")
+			if s.ReadNil() {
+				x.StringInt64Map = nil
+				return
+			}
 			x.StringInt64Map = make(map[string]*types.Int64Value)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1522,6 +1706,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_uint32_map", "stringUint32Map":
 			s.AddField("string_uint32_map")
+			if s.ReadNil() {
+				x.StringUint32Map = nil
+				return
+			}
 			x.StringUint32Map = make(map[string]*types.UInt32Value)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1536,6 +1724,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_uint64_map", "stringUint64Map":
 			s.AddField("string_uint64_map")
+			if s.ReadNil() {
+				x.StringUint64Map = nil
+				return
+			}
 			x.StringUint64Map = make(map[string]*types.UInt64Value)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1550,6 +1742,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_bool_map", "stringBoolMap":
 			s.AddField("string_bool_map")
+			if s.ReadNil() {
+				x.StringBoolMap = nil
+				return
+			}
 			x.StringBoolMap = make(map[string]*types.BoolValue)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1564,6 +1760,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_string_map", "stringStringMap":
 			s.AddField("string_string_map")
+			if s.ReadNil() {
+				x.StringStringMap = nil
+				return
+			}
 			x.StringStringMap = make(map[string]*types.StringValue)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1578,6 +1778,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_bytes_map", "stringBytesMap":
 			s.AddField("string_bytes_map")
+			if s.ReadNil() {
+				x.StringBytesMap = nil
+				return
+			}
 			x.StringBytesMap = make(map[string]*types.BytesValue)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1592,6 +1796,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_empty_map", "stringEmptyMap":
 			s.AddField("string_empty_map")
+			if s.ReadNil() {
+				x.StringEmptyMap = nil
+				return
+			}
 			x.StringEmptyMap = make(map[string]*types.Empty)
 			s.ReadStringMap(func(key string) {
 				v := gogo.UnmarshalEmpty(s)
@@ -1602,6 +1810,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_timestamp_map", "stringTimestampMap":
 			s.AddField("string_timestamp_map")
+			if s.ReadNil() {
+				x.StringTimestampMap = nil
+				return
+			}
 			x.StringTimestampMap = make(map[string]*types.Timestamp)
 			s.ReadStringMap(func(key string) {
 				v := gogo.UnmarshalTimestamp(s)
@@ -1612,6 +1824,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_duration_map", "stringDurationMap":
 			s.AddField("string_duration_map")
+			if s.ReadNil() {
+				x.StringDurationMap = nil
+				return
+			}
 			x.StringDurationMap = make(map[string]*types.Duration)
 			s.ReadStringMap(func(key string) {
 				v := gogo.UnmarshalDuration(s)
@@ -1622,6 +1838,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_field_mask_map", "stringFieldMaskMap":
 			s.AddField("string_field_mask_map")
+			if s.ReadNil() {
+				x.StringFieldMaskMap = nil
+				return
+			}
 			x.StringFieldMaskMap = make(map[string]*types.FieldMask)
 			s.ReadStringMap(func(key string) {
 				v := gogo.UnmarshalFieldMask(s)
@@ -1632,6 +1852,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_value_map", "stringValueMap":
 			s.AddField("string_value_map")
+			if s.ReadNil() {
+				x.StringValueMap = nil
+				return
+			}
 			x.StringValueMap = make(map[string]*types.Value)
 			s.ReadStringMap(func(key string) {
 				v := gogo.UnmarshalValue(s)
@@ -1642,6 +1866,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_list_value_map", "stringListValueMap":
 			s.AddField("string_list_value_map")
+			if s.ReadNil() {
+				x.StringListValueMap = nil
+				return
+			}
 			x.StringListValueMap = make(map[string]*types.ListValue)
 			s.ReadStringMap(func(key string) {
 				v := gogo.UnmarshalListValue(s)
@@ -1652,6 +1880,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_struct_map", "stringStructMap":
 			s.AddField("string_struct_map")
+			if s.ReadNil() {
+				x.StringStructMap = nil
+				return
+			}
 			x.StringStructMap = make(map[string]*types.Struct)
 			s.ReadStringMap(func(key string) {
 				v := gogo.UnmarshalStruct(s)
@@ -1662,6 +1894,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_any_map", "stringAnyMap":
 			s.AddField("string_any_map")
+			if s.ReadNil() {
+				x.StringAnyMap = nil
+				return
+			}
 			x.StringAnyMap = make(map[string]*types.Any)
 			s.ReadStringMap(func(key string) {
 				v := gogo.UnmarshalAny(s)

--- a/test/golang/enums_json.pb.go
+++ b/test/golang/enums_json.pb.go
@@ -173,6 +173,10 @@ func (x *MessageWithEnums) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.Regular = RegularEnum(s.ReadEnum(RegularEnum_value))
 		case "regulars":
 			s.AddField("regulars")
+			if s.ReadNil() {
+				x.Regulars = nil
+				return
+			}
 			s.ReadArray(func() {
 				x.Regulars = append(x.Regulars, RegularEnum(s.ReadEnum(RegularEnum_value)))
 			})
@@ -181,6 +185,10 @@ func (x *MessageWithEnums) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.Custom.UnmarshalProtoJSON(s)
 		case "customs":
 			s.AddField("customs")
+			if s.ReadNil() {
+				x.Customs = nil
+				return
+			}
 			s.ReadArray(func() {
 				var v CustomEnum
 				v.UnmarshalProtoJSON(s)
@@ -188,12 +196,18 @@ func (x *MessageWithEnums) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "wrapped_custom", "wrappedCustom":
 			s.AddField("wrapped_custom")
-			if !s.ReadNil() {
-				x.WrappedCustom = &CustomEnumValue{}
-				x.WrappedCustom.UnmarshalProtoJSON(s.WithField("wrapped_custom", false))
+			if s.ReadNil() {
+				x.WrappedCustom = nil
+				return
 			}
+			x.WrappedCustom = &CustomEnumValue{}
+			x.WrappedCustom.UnmarshalProtoJSON(s.WithField("wrapped_custom", false))
 		case "wrapped_customs", "wrappedCustoms":
 			s.AddField("wrapped_customs")
+			if s.ReadNil() {
+				x.WrappedCustoms = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.WrappedCustoms = append(x.WrappedCustoms, nil)
@@ -259,21 +273,23 @@ func (x *MessageWithOneofEnums) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState)
 		case "regular":
 			s.AddField("regular")
 			ov := &MessageWithOneofEnums_Regular{}
-			ov.Regular = RegularEnum(s.ReadEnum(RegularEnum_value))
 			x.Value = ov
+			ov.Regular = RegularEnum(s.ReadEnum(RegularEnum_value))
 		case "custom":
 			s.AddField("custom")
 			ov := &MessageWithOneofEnums_Custom{}
-			ov.Custom.UnmarshalProtoJSON(s)
 			x.Value = ov
+			ov.Custom.UnmarshalProtoJSON(s)
 		case "wrapped_custom", "wrappedCustom":
 			s.AddField("wrapped_custom")
 			ov := &MessageWithOneofEnums_WrappedCustom{}
-			if !s.ReadNil() {
-				ov.WrappedCustom = &CustomEnumValue{}
-				ov.WrappedCustom.UnmarshalProtoJSON(s.WithField("wrapped_custom", false))
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.WrappedCustom = nil
+				return
+			}
+			ov.WrappedCustom = &CustomEnumValue{}
+			ov.WrappedCustom.UnmarshalProtoJSON(s.WithField("wrapped_custom", false))
 		}
 	})
 }

--- a/test/golang/gogo_json.pb.go
+++ b/test/golang/gogo_json.pb.go
@@ -104,9 +104,17 @@ func (x *MessageWithGoGoOptions) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState
 			x.NonNullableEuiWithCustomNameAndType = types.UnmarshalHEX(s.WithField("non_nullable_eui_with_custom_name_and_type", false))
 		case "euis_with_custom_name_and_type", "euisWithCustomNameAndType":
 			s.AddField("euis_with_custom_name_and_type")
+			if s.ReadNil() {
+				x.EuisWithCustomNameAndType = nil
+				return
+			}
 			x.EuisWithCustomNameAndType = types.UnmarshalHEXArray(s.WithField("euis_with_custom_name_and_type", false))
 		case "duration":
 			s.AddField("duration")
+			if s.ReadNil() {
+				x.Duration = nil
+				return
+			}
 			v := golang.UnmarshalDuration(s)
 			if s.Err() != nil {
 				return
@@ -114,6 +122,10 @@ func (x *MessageWithGoGoOptions) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState
 			x.Duration = v
 		case "non_nullable_duration", "nonNullableDuration":
 			s.AddField("non_nullable_duration")
+			if s.ReadNil() {
+				x.NonNullableDuration = nil
+				return
+			}
 			v := golang.UnmarshalDuration(s)
 			if s.Err() != nil {
 				return
@@ -121,6 +133,10 @@ func (x *MessageWithGoGoOptions) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState
 			x.NonNullableDuration = v
 		case "timestamp":
 			s.AddField("timestamp")
+			if s.ReadNil() {
+				x.Timestamp = nil
+				return
+			}
 			v := golang.UnmarshalTimestamp(s)
 			if s.Err() != nil {
 				return
@@ -128,6 +144,10 @@ func (x *MessageWithGoGoOptions) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState
 			x.Timestamp = v
 		case "non_nullable_timestamp", "nonNullableTimestamp":
 			s.AddField("non_nullable_timestamp")
+			if s.ReadNil() {
+				x.NonNullableTimestamp = nil
+				return
+			}
 			v := golang.UnmarshalTimestamp(s)
 			if s.Err() != nil {
 				return
@@ -244,12 +264,18 @@ func (x *MessageWithNullable) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 		default:
 			s.ReadAny() // ignore unknown field
 		case "sub":
-			if !s.ReadNil() {
-				x.Sub = &SubMessage{}
-				x.Sub.UnmarshalProtoJSON(s.WithField("sub", true))
+			if s.ReadNil() {
+				x.Sub = nil
+				return
 			}
+			x.Sub = &SubMessage{}
+			x.Sub.UnmarshalProtoJSON(s.WithField("sub", true))
 		case "subs":
 			s.AddField("subs")
+			if s.ReadNil() {
+				x.Subs = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.Subs = append(x.Subs, nil)
@@ -264,12 +290,20 @@ func (x *MessageWithNullable) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "other_sub", "otherSub":
 			s.AddField("other_sub")
+			if s.ReadNil() {
+				x.OtherSub = nil
+				return
+			}
 			// NOTE: SubMessageWithoutMarshalers does not seem to implement UnmarshalProtoJSON.
 			var v SubMessageWithoutMarshalers
 			golang.UnmarshalMessage(s, &v)
 			x.OtherSub = &v
 		case "other_subs", "otherSubs":
 			s.AddField("other_subs")
+			if s.ReadNil() {
+				x.OtherSubs = nil
+				return
+			}
 			s.ReadArray(func() {
 				// NOTE: SubMessageWithoutMarshalers does not seem to implement UnmarshalProtoJSON.
 				var v SubMessageWithoutMarshalers
@@ -322,12 +356,18 @@ func (x *MessageWithEmbedded) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 		default:
 			s.ReadAny() // ignore unknown field
 		case "sub":
-			if !s.ReadNil() {
-				x.Sub = &SubMessage{}
-				x.Sub.UnmarshalProtoJSON(s.WithField("sub", true))
+			if s.ReadNil() {
+				x.Sub = nil
+				return
 			}
+			x.Sub = &SubMessage{}
+			x.Sub.UnmarshalProtoJSON(s.WithField("sub", true))
 		case "other_sub", "otherSub":
 			s.AddField("other_sub")
+			if s.ReadNil() {
+				x.OtherSub = nil
+				return
+			}
 			// NOTE: SubMessageWithoutMarshalers does not seem to implement UnmarshalProtoJSON.
 			var v SubMessageWithoutMarshalers
 			golang.UnmarshalMessage(s, &v)
@@ -378,12 +418,18 @@ func (x *MessageWithNullableEmbedded) UnmarshalProtoJSON(s *jsonplugin.Unmarshal
 		default:
 			s.ReadAny() // ignore unknown field
 		case "sub":
-			if !s.ReadNil() {
-				x.Sub = &SubMessage{}
-				x.Sub.UnmarshalProtoJSON(s.WithField("sub", true))
+			if s.ReadNil() {
+				x.Sub = nil
+				return
 			}
+			x.Sub = &SubMessage{}
+			x.Sub.UnmarshalProtoJSON(s.WithField("sub", true))
 		case "other_sub", "otherSub":
 			s.AddField("other_sub")
+			if s.ReadNil() {
+				x.OtherSub = nil
+				return
+			}
 			// NOTE: SubMessageWithoutMarshalers does not seem to implement UnmarshalProtoJSON.
 			var v SubMessageWithoutMarshalers
 			golang.UnmarshalMessage(s, &v)

--- a/test/golang/scalars_json.pb.go
+++ b/test/golang/scalars_json.pb.go
@@ -201,96 +201,160 @@ func (x *MessageWithScalars) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.DoubleValue = s.ReadFloat64()
 		case "double_values", "doubleValues":
 			s.AddField("double_values")
+			if s.ReadNil() {
+				x.DoubleValues = nil
+				return
+			}
 			x.DoubleValues = s.ReadFloat64Array()
 		case "float_value", "floatValue":
 			s.AddField("float_value")
 			x.FloatValue = s.ReadFloat32()
 		case "float_values", "floatValues":
 			s.AddField("float_values")
+			if s.ReadNil() {
+				x.FloatValues = nil
+				return
+			}
 			x.FloatValues = s.ReadFloat32Array()
 		case "int32_value", "int32Value":
 			s.AddField("int32_value")
 			x.Int32Value = s.ReadInt32()
 		case "int32_values", "int32Values":
 			s.AddField("int32_values")
+			if s.ReadNil() {
+				x.Int32Values = nil
+				return
+			}
 			x.Int32Values = s.ReadInt32Array()
 		case "int64_value", "int64Value":
 			s.AddField("int64_value")
 			x.Int64Value = s.ReadInt64()
 		case "int64_values", "int64Values":
 			s.AddField("int64_values")
+			if s.ReadNil() {
+				x.Int64Values = nil
+				return
+			}
 			x.Int64Values = s.ReadInt64Array()
 		case "uint32_value", "uint32Value":
 			s.AddField("uint32_value")
 			x.Uint32Value = s.ReadUint32()
 		case "uint32_values", "uint32Values":
 			s.AddField("uint32_values")
+			if s.ReadNil() {
+				x.Uint32Values = nil
+				return
+			}
 			x.Uint32Values = s.ReadUint32Array()
 		case "uint64_value", "uint64Value":
 			s.AddField("uint64_value")
 			x.Uint64Value = s.ReadUint64()
 		case "uint64_values", "uint64Values":
 			s.AddField("uint64_values")
+			if s.ReadNil() {
+				x.Uint64Values = nil
+				return
+			}
 			x.Uint64Values = s.ReadUint64Array()
 		case "sint32_value", "sint32Value":
 			s.AddField("sint32_value")
 			x.Sint32Value = s.ReadInt32()
 		case "sint32_values", "sint32Values":
 			s.AddField("sint32_values")
+			if s.ReadNil() {
+				x.Sint32Values = nil
+				return
+			}
 			x.Sint32Values = s.ReadInt32Array()
 		case "sint64_value", "sint64Value":
 			s.AddField("sint64_value")
 			x.Sint64Value = s.ReadInt64()
 		case "sint64_values", "sint64Values":
 			s.AddField("sint64_values")
+			if s.ReadNil() {
+				x.Sint64Values = nil
+				return
+			}
 			x.Sint64Values = s.ReadInt64Array()
 		case "fixed32_value", "fixed32Value":
 			s.AddField("fixed32_value")
 			x.Fixed32Value = s.ReadUint32()
 		case "fixed32_values", "fixed32Values":
 			s.AddField("fixed32_values")
+			if s.ReadNil() {
+				x.Fixed32Values = nil
+				return
+			}
 			x.Fixed32Values = s.ReadUint32Array()
 		case "fixed64_value", "fixed64Value":
 			s.AddField("fixed64_value")
 			x.Fixed64Value = s.ReadUint64()
 		case "fixed64_values", "fixed64Values":
 			s.AddField("fixed64_values")
+			if s.ReadNil() {
+				x.Fixed64Values = nil
+				return
+			}
 			x.Fixed64Values = s.ReadUint64Array()
 		case "sfixed32_value", "sfixed32Value":
 			s.AddField("sfixed32_value")
 			x.Sfixed32Value = s.ReadInt32()
 		case "sfixed32_values", "sfixed32Values":
 			s.AddField("sfixed32_values")
+			if s.ReadNil() {
+				x.Sfixed32Values = nil
+				return
+			}
 			x.Sfixed32Values = s.ReadInt32Array()
 		case "sfixed64_value", "sfixed64Value":
 			s.AddField("sfixed64_value")
 			x.Sfixed64Value = s.ReadInt64()
 		case "sfixed64_values", "sfixed64Values":
 			s.AddField("sfixed64_values")
+			if s.ReadNil() {
+				x.Sfixed64Values = nil
+				return
+			}
 			x.Sfixed64Values = s.ReadInt64Array()
 		case "bool_value", "boolValue":
 			s.AddField("bool_value")
 			x.BoolValue = s.ReadBool()
 		case "bool_values", "boolValues":
 			s.AddField("bool_values")
+			if s.ReadNil() {
+				x.BoolValues = nil
+				return
+			}
 			x.BoolValues = s.ReadBoolArray()
 		case "string_value", "stringValue":
 			s.AddField("string_value")
 			x.StringValue = s.ReadString()
 		case "string_values", "stringValues":
 			s.AddField("string_values")
+			if s.ReadNil() {
+				x.StringValues = nil
+				return
+			}
 			x.StringValues = s.ReadStringArray()
 		case "bytes_value", "bytesValue":
 			s.AddField("bytes_value")
 			x.BytesValue = s.ReadBytes()
 		case "bytes_values", "bytesValues":
 			s.AddField("bytes_values")
+			if s.ReadNil() {
+				x.BytesValues = nil
+				return
+			}
 			x.BytesValues = s.ReadBytesArray()
 		case "hex_bytes_value", "hexBytesValue":
 			s.AddField("hex_bytes_value")
 			x.HexBytesValue = types.UnmarshalHEX(s.WithField("hex_bytes_value", false))
 		case "hex_bytes_values", "hexBytesValues":
 			s.AddField("hex_bytes_values")
+			if s.ReadNil() {
+				x.HexBytesValues = nil
+				return
+			}
 			x.HexBytesValues = types.UnmarshalHEXArray(s.WithField("hex_bytes_values", false))
 		}
 	})
@@ -397,83 +461,83 @@ func (x *MessageWithOneofScalars) UnmarshalProtoJSON(s *jsonplugin.UnmarshalStat
 		case "double_value", "doubleValue":
 			s.AddField("double_value")
 			ov := &MessageWithOneofScalars_DoubleValue{}
-			ov.DoubleValue = s.ReadFloat64()
 			x.Value = ov
+			ov.DoubleValue = s.ReadFloat64()
 		case "float_value", "floatValue":
 			s.AddField("float_value")
 			ov := &MessageWithOneofScalars_FloatValue{}
-			ov.FloatValue = s.ReadFloat32()
 			x.Value = ov
+			ov.FloatValue = s.ReadFloat32()
 		case "int32_value", "int32Value":
 			s.AddField("int32_value")
 			ov := &MessageWithOneofScalars_Int32Value{}
-			ov.Int32Value = s.ReadInt32()
 			x.Value = ov
+			ov.Int32Value = s.ReadInt32()
 		case "int64_value", "int64Value":
 			s.AddField("int64_value")
 			ov := &MessageWithOneofScalars_Int64Value{}
-			ov.Int64Value = s.ReadInt64()
 			x.Value = ov
+			ov.Int64Value = s.ReadInt64()
 		case "uint32_value", "uint32Value":
 			s.AddField("uint32_value")
 			ov := &MessageWithOneofScalars_Uint32Value{}
-			ov.Uint32Value = s.ReadUint32()
 			x.Value = ov
+			ov.Uint32Value = s.ReadUint32()
 		case "uint64_value", "uint64Value":
 			s.AddField("uint64_value")
 			ov := &MessageWithOneofScalars_Uint64Value{}
-			ov.Uint64Value = s.ReadUint64()
 			x.Value = ov
+			ov.Uint64Value = s.ReadUint64()
 		case "sint32_value", "sint32Value":
 			s.AddField("sint32_value")
 			ov := &MessageWithOneofScalars_Sint32Value{}
-			ov.Sint32Value = s.ReadInt32()
 			x.Value = ov
+			ov.Sint32Value = s.ReadInt32()
 		case "sint64_value", "sint64Value":
 			s.AddField("sint64_value")
 			ov := &MessageWithOneofScalars_Sint64Value{}
-			ov.Sint64Value = s.ReadInt64()
 			x.Value = ov
+			ov.Sint64Value = s.ReadInt64()
 		case "fixed32_value", "fixed32Value":
 			s.AddField("fixed32_value")
 			ov := &MessageWithOneofScalars_Fixed32Value{}
-			ov.Fixed32Value = s.ReadUint32()
 			x.Value = ov
+			ov.Fixed32Value = s.ReadUint32()
 		case "fixed64_value", "fixed64Value":
 			s.AddField("fixed64_value")
 			ov := &MessageWithOneofScalars_Fixed64Value{}
-			ov.Fixed64Value = s.ReadUint64()
 			x.Value = ov
+			ov.Fixed64Value = s.ReadUint64()
 		case "sfixed32_value", "sfixed32Value":
 			s.AddField("sfixed32_value")
 			ov := &MessageWithOneofScalars_Sfixed32Value{}
-			ov.Sfixed32Value = s.ReadInt32()
 			x.Value = ov
+			ov.Sfixed32Value = s.ReadInt32()
 		case "sfixed64_value", "sfixed64Value":
 			s.AddField("sfixed64_value")
 			ov := &MessageWithOneofScalars_Sfixed64Value{}
-			ov.Sfixed64Value = s.ReadInt64()
 			x.Value = ov
+			ov.Sfixed64Value = s.ReadInt64()
 		case "bool_value", "boolValue":
 			s.AddField("bool_value")
 			ov := &MessageWithOneofScalars_BoolValue{}
-			ov.BoolValue = s.ReadBool()
 			x.Value = ov
+			ov.BoolValue = s.ReadBool()
 		case "string_value", "stringValue":
 			s.AddField("string_value")
 			ov := &MessageWithOneofScalars_StringValue{}
-			ov.StringValue = s.ReadString()
 			x.Value = ov
+			ov.StringValue = s.ReadString()
 		case "bytes_value", "bytesValue":
 			s.AddField("bytes_value")
 			ov := &MessageWithOneofScalars_BytesValue{}
-			ov.BytesValue = s.ReadBytes()
 			x.Value = ov
+			ov.BytesValue = s.ReadBytes()
 		case "hex_bytes_value", "hexBytesValue":
 			s.AddField("hex_bytes_value")
 			ov := &MessageWithOneofScalars_HexBytesValue{}
-			ov.HexBytesValue = types.UnmarshalHEX(s.WithField("hex_bytes_value", false))
 			x.Value = ov
+			ov.HexBytesValue = types.UnmarshalHEX(s.WithField("hex_bytes_value", false))
 		}
 	})
 }
@@ -827,162 +891,270 @@ func (x *MessageWithScalarMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState)
 			s.ReadAny() // ignore unknown field
 		case "string_double_map", "stringDoubleMap":
 			s.AddField("string_double_map")
+			if s.ReadNil() {
+				x.StringDoubleMap = nil
+				return
+			}
 			x.StringDoubleMap = make(map[string]float64)
 			s.ReadStringMap(func(key string) {
 				x.StringDoubleMap[key] = s.ReadFloat64()
 			})
 		case "string_float_map", "stringFloatMap":
 			s.AddField("string_float_map")
+			if s.ReadNil() {
+				x.StringFloatMap = nil
+				return
+			}
 			x.StringFloatMap = make(map[string]float32)
 			s.ReadStringMap(func(key string) {
 				x.StringFloatMap[key] = s.ReadFloat32()
 			})
 		case "string_int32_map", "stringInt32Map":
 			s.AddField("string_int32_map")
+			if s.ReadNil() {
+				x.StringInt32Map = nil
+				return
+			}
 			x.StringInt32Map = make(map[string]int32)
 			s.ReadStringMap(func(key string) {
 				x.StringInt32Map[key] = s.ReadInt32()
 			})
 		case "int32_string_map", "int32StringMap":
 			s.AddField("int32_string_map")
+			if s.ReadNil() {
+				x.Int32StringMap = nil
+				return
+			}
 			x.Int32StringMap = make(map[int32]string)
 			s.ReadInt32Map(func(key int32) {
 				x.Int32StringMap[key] = s.ReadString()
 			})
 		case "string_int64_map", "stringInt64Map":
 			s.AddField("string_int64_map")
+			if s.ReadNil() {
+				x.StringInt64Map = nil
+				return
+			}
 			x.StringInt64Map = make(map[string]int64)
 			s.ReadStringMap(func(key string) {
 				x.StringInt64Map[key] = s.ReadInt64()
 			})
 		case "int64_string_map", "int64StringMap":
 			s.AddField("int64_string_map")
+			if s.ReadNil() {
+				x.Int64StringMap = nil
+				return
+			}
 			x.Int64StringMap = make(map[int64]string)
 			s.ReadInt64Map(func(key int64) {
 				x.Int64StringMap[key] = s.ReadString()
 			})
 		case "string_uint32_map", "stringUint32Map":
 			s.AddField("string_uint32_map")
+			if s.ReadNil() {
+				x.StringUint32Map = nil
+				return
+			}
 			x.StringUint32Map = make(map[string]uint32)
 			s.ReadStringMap(func(key string) {
 				x.StringUint32Map[key] = s.ReadUint32()
 			})
 		case "uint32_string_map", "uint32StringMap":
 			s.AddField("uint32_string_map")
+			if s.ReadNil() {
+				x.Uint32StringMap = nil
+				return
+			}
 			x.Uint32StringMap = make(map[uint32]string)
 			s.ReadUint32Map(func(key uint32) {
 				x.Uint32StringMap[key] = s.ReadString()
 			})
 		case "string_uint64_map", "stringUint64Map":
 			s.AddField("string_uint64_map")
+			if s.ReadNil() {
+				x.StringUint64Map = nil
+				return
+			}
 			x.StringUint64Map = make(map[string]uint64)
 			s.ReadStringMap(func(key string) {
 				x.StringUint64Map[key] = s.ReadUint64()
 			})
 		case "uint64_string_map", "uint64StringMap":
 			s.AddField("uint64_string_map")
+			if s.ReadNil() {
+				x.Uint64StringMap = nil
+				return
+			}
 			x.Uint64StringMap = make(map[uint64]string)
 			s.ReadUint64Map(func(key uint64) {
 				x.Uint64StringMap[key] = s.ReadString()
 			})
 		case "string_sint32_map", "stringSint32Map":
 			s.AddField("string_sint32_map")
+			if s.ReadNil() {
+				x.StringSint32Map = nil
+				return
+			}
 			x.StringSint32Map = make(map[string]int32)
 			s.ReadStringMap(func(key string) {
 				x.StringSint32Map[key] = s.ReadInt32()
 			})
 		case "sint32_string_map", "sint32StringMap":
 			s.AddField("sint32_string_map")
+			if s.ReadNil() {
+				x.Sint32StringMap = nil
+				return
+			}
 			x.Sint32StringMap = make(map[int32]string)
 			s.ReadInt32Map(func(key int32) {
 				x.Sint32StringMap[key] = s.ReadString()
 			})
 		case "string_sint64_map", "stringSint64Map":
 			s.AddField("string_sint64_map")
+			if s.ReadNil() {
+				x.StringSint64Map = nil
+				return
+			}
 			x.StringSint64Map = make(map[string]int64)
 			s.ReadStringMap(func(key string) {
 				x.StringSint64Map[key] = s.ReadInt64()
 			})
 		case "sint64_string_map", "sint64StringMap":
 			s.AddField("sint64_string_map")
+			if s.ReadNil() {
+				x.Sint64StringMap = nil
+				return
+			}
 			x.Sint64StringMap = make(map[int64]string)
 			s.ReadInt64Map(func(key int64) {
 				x.Sint64StringMap[key] = s.ReadString()
 			})
 		case "string_fixed32_map", "stringFixed32Map":
 			s.AddField("string_fixed32_map")
+			if s.ReadNil() {
+				x.StringFixed32Map = nil
+				return
+			}
 			x.StringFixed32Map = make(map[string]uint32)
 			s.ReadStringMap(func(key string) {
 				x.StringFixed32Map[key] = s.ReadUint32()
 			})
 		case "fixed32_string_map", "fixed32StringMap":
 			s.AddField("fixed32_string_map")
+			if s.ReadNil() {
+				x.Fixed32StringMap = nil
+				return
+			}
 			x.Fixed32StringMap = make(map[uint32]string)
 			s.ReadUint32Map(func(key uint32) {
 				x.Fixed32StringMap[key] = s.ReadString()
 			})
 		case "string_fixed64_map", "stringFixed64Map":
 			s.AddField("string_fixed64_map")
+			if s.ReadNil() {
+				x.StringFixed64Map = nil
+				return
+			}
 			x.StringFixed64Map = make(map[string]uint64)
 			s.ReadStringMap(func(key string) {
 				x.StringFixed64Map[key] = s.ReadUint64()
 			})
 		case "fixed64_string_map", "fixed64StringMap":
 			s.AddField("fixed64_string_map")
+			if s.ReadNil() {
+				x.Fixed64StringMap = nil
+				return
+			}
 			x.Fixed64StringMap = make(map[uint64]string)
 			s.ReadUint64Map(func(key uint64) {
 				x.Fixed64StringMap[key] = s.ReadString()
 			})
 		case "string_sfixed32_map", "stringSfixed32Map":
 			s.AddField("string_sfixed32_map")
+			if s.ReadNil() {
+				x.StringSfixed32Map = nil
+				return
+			}
 			x.StringSfixed32Map = make(map[string]int32)
 			s.ReadStringMap(func(key string) {
 				x.StringSfixed32Map[key] = s.ReadInt32()
 			})
 		case "sfixed32_string_map", "sfixed32StringMap":
 			s.AddField("sfixed32_string_map")
+			if s.ReadNil() {
+				x.Sfixed32StringMap = nil
+				return
+			}
 			x.Sfixed32StringMap = make(map[int32]string)
 			s.ReadInt32Map(func(key int32) {
 				x.Sfixed32StringMap[key] = s.ReadString()
 			})
 		case "string_sfixed64_map", "stringSfixed64Map":
 			s.AddField("string_sfixed64_map")
+			if s.ReadNil() {
+				x.StringSfixed64Map = nil
+				return
+			}
 			x.StringSfixed64Map = make(map[string]int64)
 			s.ReadStringMap(func(key string) {
 				x.StringSfixed64Map[key] = s.ReadInt64()
 			})
 		case "sfixed64_string_map", "sfixed64StringMap":
 			s.AddField("sfixed64_string_map")
+			if s.ReadNil() {
+				x.Sfixed64StringMap = nil
+				return
+			}
 			x.Sfixed64StringMap = make(map[int64]string)
 			s.ReadInt64Map(func(key int64) {
 				x.Sfixed64StringMap[key] = s.ReadString()
 			})
 		case "string_bool_map", "stringBoolMap":
 			s.AddField("string_bool_map")
+			if s.ReadNil() {
+				x.StringBoolMap = nil
+				return
+			}
 			x.StringBoolMap = make(map[string]bool)
 			s.ReadStringMap(func(key string) {
 				x.StringBoolMap[key] = s.ReadBool()
 			})
 		case "bool_string_map", "boolStringMap":
 			s.AddField("bool_string_map")
+			if s.ReadNil() {
+				x.BoolStringMap = nil
+				return
+			}
 			x.BoolStringMap = make(map[bool]string)
 			s.ReadBoolMap(func(key bool) {
 				x.BoolStringMap[key] = s.ReadString()
 			})
 		case "string_string_map", "stringStringMap":
 			s.AddField("string_string_map")
+			if s.ReadNil() {
+				x.StringStringMap = nil
+				return
+			}
 			x.StringStringMap = make(map[string]string)
 			s.ReadStringMap(func(key string) {
 				x.StringStringMap[key] = s.ReadString()
 			})
 		case "string_bytes_map", "stringBytesMap":
 			s.AddField("string_bytes_map")
+			if s.ReadNil() {
+				x.StringBytesMap = nil
+				return
+			}
 			x.StringBytesMap = make(map[string][]byte)
 			s.ReadStringMap(func(key string) {
 				x.StringBytesMap[key] = s.ReadBytes()
 			})
 		case "string_hex_bytes_map", "stringHexBytesMap":
 			s.AddField("string_hex_bytes_map")
+			if s.ReadNil() {
+				x.StringHexBytesMap = nil
+				return
+			}
 			x.StringHexBytesMap = types.UnmarshalStringHEXMap(s.WithField("string_hex_bytes_map", false))
 		}
 	})

--- a/test/golang/wkts_json.pb.go
+++ b/test/golang/wkts_json.pb.go
@@ -495,15 +495,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			s.ReadAny() // ignore unknown field
 		case "double_value", "doubleValue":
 			s.AddField("double_value")
-			if !s.ReadNil() {
-				v := s.ReadFloat64()
-				if s.Err() != nil {
-					return
-				}
-				x.DoubleValue = &wrapperspb.DoubleValue{Value: v}
+			if s.ReadNil() {
+				x.DoubleValue = nil
+				return
 			}
+			v := s.ReadFloat64()
+			if s.Err() != nil {
+				return
+			}
+			x.DoubleValue = &wrapperspb.DoubleValue{Value: v}
 		case "double_values", "doubleValues":
 			s.AddField("double_values")
+			if s.ReadNil() {
+				x.DoubleValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.DoubleValues = append(x.DoubleValues, nil)
@@ -517,15 +523,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "float_value", "floatValue":
 			s.AddField("float_value")
-			if !s.ReadNil() {
-				v := s.ReadFloat32()
-				if s.Err() != nil {
-					return
-				}
-				x.FloatValue = &wrapperspb.FloatValue{Value: v}
+			if s.ReadNil() {
+				x.FloatValue = nil
+				return
 			}
+			v := s.ReadFloat32()
+			if s.Err() != nil {
+				return
+			}
+			x.FloatValue = &wrapperspb.FloatValue{Value: v}
 		case "float_values", "floatValues":
 			s.AddField("float_values")
+			if s.ReadNil() {
+				x.FloatValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.FloatValues = append(x.FloatValues, nil)
@@ -539,15 +551,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "int32_value", "int32Value":
 			s.AddField("int32_value")
-			if !s.ReadNil() {
-				v := s.ReadInt32()
-				if s.Err() != nil {
-					return
-				}
-				x.Int32Value = &wrapperspb.Int32Value{Value: v}
+			if s.ReadNil() {
+				x.Int32Value = nil
+				return
 			}
+			v := s.ReadInt32()
+			if s.Err() != nil {
+				return
+			}
+			x.Int32Value = &wrapperspb.Int32Value{Value: v}
 		case "int32_values", "int32Values":
 			s.AddField("int32_values")
+			if s.ReadNil() {
+				x.Int32Values = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.Int32Values = append(x.Int32Values, nil)
@@ -561,15 +579,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "int64_value", "int64Value":
 			s.AddField("int64_value")
-			if !s.ReadNil() {
-				v := s.ReadInt64()
-				if s.Err() != nil {
-					return
-				}
-				x.Int64Value = &wrapperspb.Int64Value{Value: v}
+			if s.ReadNil() {
+				x.Int64Value = nil
+				return
 			}
+			v := s.ReadInt64()
+			if s.Err() != nil {
+				return
+			}
+			x.Int64Value = &wrapperspb.Int64Value{Value: v}
 		case "int64_values", "int64Values":
 			s.AddField("int64_values")
+			if s.ReadNil() {
+				x.Int64Values = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.Int64Values = append(x.Int64Values, nil)
@@ -583,15 +607,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "uint32_value", "uint32Value":
 			s.AddField("uint32_value")
-			if !s.ReadNil() {
-				v := s.ReadUint32()
-				if s.Err() != nil {
-					return
-				}
-				x.Uint32Value = &wrapperspb.UInt32Value{Value: v}
+			if s.ReadNil() {
+				x.Uint32Value = nil
+				return
 			}
+			v := s.ReadUint32()
+			if s.Err() != nil {
+				return
+			}
+			x.Uint32Value = &wrapperspb.UInt32Value{Value: v}
 		case "uint32_values", "uint32Values":
 			s.AddField("uint32_values")
+			if s.ReadNil() {
+				x.Uint32Values = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.Uint32Values = append(x.Uint32Values, nil)
@@ -605,15 +635,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "uint64_value", "uint64Value":
 			s.AddField("uint64_value")
-			if !s.ReadNil() {
-				v := s.ReadUint64()
-				if s.Err() != nil {
-					return
-				}
-				x.Uint64Value = &wrapperspb.UInt64Value{Value: v}
+			if s.ReadNil() {
+				x.Uint64Value = nil
+				return
 			}
+			v := s.ReadUint64()
+			if s.Err() != nil {
+				return
+			}
+			x.Uint64Value = &wrapperspb.UInt64Value{Value: v}
 		case "uint64_values", "uint64Values":
 			s.AddField("uint64_values")
+			if s.ReadNil() {
+				x.Uint64Values = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.Uint64Values = append(x.Uint64Values, nil)
@@ -627,15 +663,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "bool_value", "boolValue":
 			s.AddField("bool_value")
-			if !s.ReadNil() {
-				v := s.ReadBool()
-				if s.Err() != nil {
-					return
-				}
-				x.BoolValue = &wrapperspb.BoolValue{Value: v}
+			if s.ReadNil() {
+				x.BoolValue = nil
+				return
 			}
+			v := s.ReadBool()
+			if s.Err() != nil {
+				return
+			}
+			x.BoolValue = &wrapperspb.BoolValue{Value: v}
 		case "bool_values", "boolValues":
 			s.AddField("bool_values")
+			if s.ReadNil() {
+				x.BoolValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.BoolValues = append(x.BoolValues, nil)
@@ -649,15 +691,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_value", "stringValue":
 			s.AddField("string_value")
-			if !s.ReadNil() {
-				v := s.ReadString()
-				if s.Err() != nil {
-					return
-				}
-				x.StringValue = &wrapperspb.StringValue{Value: v}
+			if s.ReadNil() {
+				x.StringValue = nil
+				return
 			}
+			v := s.ReadString()
+			if s.Err() != nil {
+				return
+			}
+			x.StringValue = &wrapperspb.StringValue{Value: v}
 		case "string_values", "stringValues":
 			s.AddField("string_values")
+			if s.ReadNil() {
+				x.StringValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.StringValues = append(x.StringValues, nil)
@@ -671,15 +719,21 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "bytes_value", "bytesValue":
 			s.AddField("bytes_value")
-			if !s.ReadNil() {
-				v := s.ReadBytes()
-				if s.Err() != nil {
-					return
-				}
-				x.BytesValue = &wrapperspb.BytesValue{Value: v}
+			if s.ReadNil() {
+				x.BytesValue = nil
+				return
 			}
+			v := s.ReadBytes()
+			if s.Err() != nil {
+				return
+			}
+			x.BytesValue = &wrapperspb.BytesValue{Value: v}
 		case "bytes_values", "bytesValues":
 			s.AddField("bytes_values")
+			if s.ReadNil() {
+				x.BytesValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				if s.ReadNil() {
 					x.BytesValues = append(x.BytesValues, nil)
@@ -693,6 +747,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "empty_value", "emptyValue":
 			s.AddField("empty_value")
+			if s.ReadNil() {
+				x.EmptyValue = nil
+				return
+			}
 			v := golang.UnmarshalEmpty(s)
 			if s.Err() != nil {
 				return
@@ -700,6 +758,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.EmptyValue = v
 		case "empty_values", "emptyValues":
 			s.AddField("empty_values")
+			if s.ReadNil() {
+				x.EmptyValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := golang.UnmarshalEmpty(s)
 				if s.Err() != nil {
@@ -709,6 +771,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "timestamp_value", "timestampValue":
 			s.AddField("timestamp_value")
+			if s.ReadNil() {
+				x.TimestampValue = nil
+				return
+			}
 			v := golang.UnmarshalTimestamp(s)
 			if s.Err() != nil {
 				return
@@ -716,6 +782,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.TimestampValue = v
 		case "timestamp_values", "timestampValues":
 			s.AddField("timestamp_values")
+			if s.ReadNil() {
+				x.TimestampValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := golang.UnmarshalTimestamp(s)
 				if s.Err() != nil {
@@ -725,6 +795,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "duration_value", "durationValue":
 			s.AddField("duration_value")
+			if s.ReadNil() {
+				x.DurationValue = nil
+				return
+			}
 			v := golang.UnmarshalDuration(s)
 			if s.Err() != nil {
 				return
@@ -732,6 +806,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.DurationValue = v
 		case "duration_values", "durationValues":
 			s.AddField("duration_values")
+			if s.ReadNil() {
+				x.DurationValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := golang.UnmarshalDuration(s)
 				if s.Err() != nil {
@@ -741,6 +819,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "field_mask_value", "fieldMaskValue":
 			s.AddField("field_mask_value")
+			if s.ReadNil() {
+				x.FieldMaskValue = nil
+				return
+			}
 			v := golang.UnmarshalFieldMask(s)
 			if s.Err() != nil {
 				return
@@ -748,6 +830,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.FieldMaskValue = v
 		case "field_mask_values", "fieldMaskValues":
 			s.AddField("field_mask_values")
+			if s.ReadNil() {
+				x.FieldMaskValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := golang.UnmarshalFieldMask(s)
 				if s.Err() != nil {
@@ -757,6 +843,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "value_value", "valueValue":
 			s.AddField("value_value")
+			if s.ReadNil() {
+				x.ValueValue = &structpb.Value{Kind: &structpb.Value_NullValue{}}
+				return
+			}
 			v := golang.UnmarshalValue(s)
 			if s.Err() != nil {
 				return
@@ -764,6 +854,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.ValueValue = v
 		case "value_values", "valueValues":
 			s.AddField("value_values")
+			if s.ReadNil() {
+				x.ValueValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := golang.UnmarshalValue(s)
 				if s.Err() != nil {
@@ -773,6 +867,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "list_value_value", "listValueValue":
 			s.AddField("list_value_value")
+			if s.ReadNil() {
+				x.ListValueValue = nil
+				return
+			}
 			v := golang.UnmarshalListValue(s)
 			if s.Err() != nil {
 				return
@@ -780,6 +878,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.ListValueValue = v
 		case "list_value_values", "listValueValues":
 			s.AddField("list_value_values")
+			if s.ReadNil() {
+				x.ListValueValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := golang.UnmarshalListValue(s)
 				if s.Err() != nil {
@@ -789,6 +891,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "struct_value", "structValue":
 			s.AddField("struct_value")
+			if s.ReadNil() {
+				x.StructValue = nil
+				return
+			}
 			v := golang.UnmarshalStruct(s)
 			if s.Err() != nil {
 				return
@@ -796,6 +902,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.StructValue = v
 		case "struct_values", "structValues":
 			s.AddField("struct_values")
+			if s.ReadNil() {
+				x.StructValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := golang.UnmarshalStruct(s)
 				if s.Err() != nil {
@@ -805,6 +915,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "any_value", "anyValue":
 			s.AddField("any_value")
+			if s.ReadNil() {
+				x.AnyValue = nil
+				return
+			}
 			v := golang.UnmarshalAny(s)
 			if s.Err() != nil {
 				return
@@ -812,6 +926,10 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			x.AnyValue = v
 		case "any_values", "anyValues":
 			s.AddField("any_values")
+			if s.ReadNil() {
+				x.AnyValues = nil
+				return
+			}
 			s.ReadArray(func() {
 				v := golang.UnmarshalAny(s)
 				if s.Err() != nil {
@@ -996,174 +1114,224 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 		case "double_value", "doubleValue":
 			s.AddField("double_value")
 			ov := &MessageWithOneofWKTs_DoubleValue{}
-			if !s.ReadNil() {
-				v := s.ReadFloat64()
-				if s.Err() != nil {
-					return
-				}
-				ov.DoubleValue = &wrapperspb.DoubleValue{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.DoubleValue = nil
+				return
+			}
+			v := s.ReadFloat64()
+			if s.Err() != nil {
+				return
+			}
+			ov.DoubleValue = &wrapperspb.DoubleValue{Value: v}
 		case "float_value", "floatValue":
 			s.AddField("float_value")
 			ov := &MessageWithOneofWKTs_FloatValue{}
-			if !s.ReadNil() {
-				v := s.ReadFloat32()
-				if s.Err() != nil {
-					return
-				}
-				ov.FloatValue = &wrapperspb.FloatValue{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.FloatValue = nil
+				return
+			}
+			v := s.ReadFloat32()
+			if s.Err() != nil {
+				return
+			}
+			ov.FloatValue = &wrapperspb.FloatValue{Value: v}
 		case "int32_value", "int32Value":
 			s.AddField("int32_value")
 			ov := &MessageWithOneofWKTs_Int32Value{}
-			if !s.ReadNil() {
-				v := s.ReadInt32()
-				if s.Err() != nil {
-					return
-				}
-				ov.Int32Value = &wrapperspb.Int32Value{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.Int32Value = nil
+				return
+			}
+			v := s.ReadInt32()
+			if s.Err() != nil {
+				return
+			}
+			ov.Int32Value = &wrapperspb.Int32Value{Value: v}
 		case "int64_value", "int64Value":
 			s.AddField("int64_value")
 			ov := &MessageWithOneofWKTs_Int64Value{}
-			if !s.ReadNil() {
-				v := s.ReadInt64()
-				if s.Err() != nil {
-					return
-				}
-				ov.Int64Value = &wrapperspb.Int64Value{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.Int64Value = nil
+				return
+			}
+			v := s.ReadInt64()
+			if s.Err() != nil {
+				return
+			}
+			ov.Int64Value = &wrapperspb.Int64Value{Value: v}
 		case "uint32_value", "uint32Value":
 			s.AddField("uint32_value")
 			ov := &MessageWithOneofWKTs_Uint32Value{}
-			if !s.ReadNil() {
-				v := s.ReadUint32()
-				if s.Err() != nil {
-					return
-				}
-				ov.Uint32Value = &wrapperspb.UInt32Value{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.Uint32Value = nil
+				return
+			}
+			v := s.ReadUint32()
+			if s.Err() != nil {
+				return
+			}
+			ov.Uint32Value = &wrapperspb.UInt32Value{Value: v}
 		case "uint64_value", "uint64Value":
 			s.AddField("uint64_value")
 			ov := &MessageWithOneofWKTs_Uint64Value{}
-			if !s.ReadNil() {
-				v := s.ReadUint64()
-				if s.Err() != nil {
-					return
-				}
-				ov.Uint64Value = &wrapperspb.UInt64Value{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.Uint64Value = nil
+				return
+			}
+			v := s.ReadUint64()
+			if s.Err() != nil {
+				return
+			}
+			ov.Uint64Value = &wrapperspb.UInt64Value{Value: v}
 		case "bool_value", "boolValue":
 			s.AddField("bool_value")
 			ov := &MessageWithOneofWKTs_BoolValue{}
-			if !s.ReadNil() {
-				v := s.ReadBool()
-				if s.Err() != nil {
-					return
-				}
-				ov.BoolValue = &wrapperspb.BoolValue{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.BoolValue = nil
+				return
+			}
+			v := s.ReadBool()
+			if s.Err() != nil {
+				return
+			}
+			ov.BoolValue = &wrapperspb.BoolValue{Value: v}
 		case "string_value", "stringValue":
 			s.AddField("string_value")
 			ov := &MessageWithOneofWKTs_StringValue{}
-			if !s.ReadNil() {
-				v := s.ReadString()
-				if s.Err() != nil {
-					return
-				}
-				ov.StringValue = &wrapperspb.StringValue{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.StringValue = nil
+				return
+			}
+			v := s.ReadString()
+			if s.Err() != nil {
+				return
+			}
+			ov.StringValue = &wrapperspb.StringValue{Value: v}
 		case "bytes_value", "bytesValue":
 			s.AddField("bytes_value")
 			ov := &MessageWithOneofWKTs_BytesValue{}
-			if !s.ReadNil() {
-				v := s.ReadBytes()
-				if s.Err() != nil {
-					return
-				}
-				ov.BytesValue = &wrapperspb.BytesValue{Value: v}
-			}
 			x.Value = ov
+			if s.ReadNil() {
+				ov.BytesValue = nil
+				return
+			}
+			v := s.ReadBytes()
+			if s.Err() != nil {
+				return
+			}
+			ov.BytesValue = &wrapperspb.BytesValue{Value: v}
 		case "empty_value", "emptyValue":
 			s.AddField("empty_value")
 			ov := &MessageWithOneofWKTs_EmptyValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.EmptyValue = nil
+				return
+			}
 			v := golang.UnmarshalEmpty(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.EmptyValue = v
-			x.Value = ov
 		case "timestamp_value", "timestampValue":
 			s.AddField("timestamp_value")
 			ov := &MessageWithOneofWKTs_TimestampValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.TimestampValue = nil
+				return
+			}
 			v := golang.UnmarshalTimestamp(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.TimestampValue = v
-			x.Value = ov
 		case "duration_value", "durationValue":
 			s.AddField("duration_value")
 			ov := &MessageWithOneofWKTs_DurationValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.DurationValue = nil
+				return
+			}
 			v := golang.UnmarshalDuration(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.DurationValue = v
-			x.Value = ov
 		case "field_mask_value", "fieldMaskValue":
 			s.AddField("field_mask_value")
 			ov := &MessageWithOneofWKTs_FieldMaskValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.FieldMaskValue = nil
+				return
+			}
 			v := golang.UnmarshalFieldMask(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.FieldMaskValue = v
-			x.Value = ov
 		case "value_value", "valueValue":
 			s.AddField("value_value")
 			ov := &MessageWithOneofWKTs_ValueValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.ValueValue = &structpb.Value{Kind: &structpb.Value_NullValue{}}
+				return
+			}
 			v := golang.UnmarshalValue(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.ValueValue = v
-			x.Value = ov
 		case "list_value_value", "listValueValue":
 			s.AddField("list_value_value")
 			ov := &MessageWithOneofWKTs_ListValueValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.ListValueValue = nil
+				return
+			}
 			v := golang.UnmarshalListValue(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.ListValueValue = v
-			x.Value = ov
 		case "struct_value", "structValue":
 			s.AddField("struct_value")
 			ov := &MessageWithOneofWKTs_StructValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.StructValue = nil
+				return
+			}
 			v := golang.UnmarshalStruct(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.StructValue = v
-			x.Value = ov
 		case "any_value", "anyValue":
 			s.AddField("any_value")
 			ov := &MessageWithOneofWKTs_AnyValue{}
+			x.Value = ov
+			if s.ReadNil() {
+				ov.AnyValue = nil
+				return
+			}
 			v := golang.UnmarshalAny(s)
 			if s.Err() != nil {
 				return
 			}
 			ov.AnyValue = v
-			x.Value = ov
 		}
 	})
 }
@@ -1472,6 +1640,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			s.ReadAny() // ignore unknown field
 		case "string_double_map", "stringDoubleMap":
 			s.AddField("string_double_map")
+			if s.ReadNil() {
+				x.StringDoubleMap = nil
+				return
+			}
 			x.StringDoubleMap = make(map[string]*wrapperspb.DoubleValue)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1486,6 +1658,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_float_map", "stringFloatMap":
 			s.AddField("string_float_map")
+			if s.ReadNil() {
+				x.StringFloatMap = nil
+				return
+			}
 			x.StringFloatMap = make(map[string]*wrapperspb.FloatValue)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1500,6 +1676,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_int32_map", "stringInt32Map":
 			s.AddField("string_int32_map")
+			if s.ReadNil() {
+				x.StringInt32Map = nil
+				return
+			}
 			x.StringInt32Map = make(map[string]*wrapperspb.Int32Value)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1514,6 +1694,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_int64_map", "stringInt64Map":
 			s.AddField("string_int64_map")
+			if s.ReadNil() {
+				x.StringInt64Map = nil
+				return
+			}
 			x.StringInt64Map = make(map[string]*wrapperspb.Int64Value)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1528,6 +1712,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_uint32_map", "stringUint32Map":
 			s.AddField("string_uint32_map")
+			if s.ReadNil() {
+				x.StringUint32Map = nil
+				return
+			}
 			x.StringUint32Map = make(map[string]*wrapperspb.UInt32Value)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1542,6 +1730,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_uint64_map", "stringUint64Map":
 			s.AddField("string_uint64_map")
+			if s.ReadNil() {
+				x.StringUint64Map = nil
+				return
+			}
 			x.StringUint64Map = make(map[string]*wrapperspb.UInt64Value)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1556,6 +1748,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_bool_map", "stringBoolMap":
 			s.AddField("string_bool_map")
+			if s.ReadNil() {
+				x.StringBoolMap = nil
+				return
+			}
 			x.StringBoolMap = make(map[string]*wrapperspb.BoolValue)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1570,6 +1766,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_string_map", "stringStringMap":
 			s.AddField("string_string_map")
+			if s.ReadNil() {
+				x.StringStringMap = nil
+				return
+			}
 			x.StringStringMap = make(map[string]*wrapperspb.StringValue)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1584,6 +1784,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_bytes_map", "stringBytesMap":
 			s.AddField("string_bytes_map")
+			if s.ReadNil() {
+				x.StringBytesMap = nil
+				return
+			}
 			x.StringBytesMap = make(map[string]*wrapperspb.BytesValue)
 			s.ReadStringMap(func(key string) {
 				if s.ReadNil() {
@@ -1598,6 +1802,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_empty_map", "stringEmptyMap":
 			s.AddField("string_empty_map")
+			if s.ReadNil() {
+				x.StringEmptyMap = nil
+				return
+			}
 			x.StringEmptyMap = make(map[string]*emptypb.Empty)
 			s.ReadStringMap(func(key string) {
 				v := golang.UnmarshalEmpty(s)
@@ -1608,6 +1816,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_timestamp_map", "stringTimestampMap":
 			s.AddField("string_timestamp_map")
+			if s.ReadNil() {
+				x.StringTimestampMap = nil
+				return
+			}
 			x.StringTimestampMap = make(map[string]*timestamppb.Timestamp)
 			s.ReadStringMap(func(key string) {
 				v := golang.UnmarshalTimestamp(s)
@@ -1618,6 +1830,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_duration_map", "stringDurationMap":
 			s.AddField("string_duration_map")
+			if s.ReadNil() {
+				x.StringDurationMap = nil
+				return
+			}
 			x.StringDurationMap = make(map[string]*durationpb.Duration)
 			s.ReadStringMap(func(key string) {
 				v := golang.UnmarshalDuration(s)
@@ -1628,6 +1844,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_field_mask_map", "stringFieldMaskMap":
 			s.AddField("string_field_mask_map")
+			if s.ReadNil() {
+				x.StringFieldMaskMap = nil
+				return
+			}
 			x.StringFieldMaskMap = make(map[string]*fieldmaskpb.FieldMask)
 			s.ReadStringMap(func(key string) {
 				v := golang.UnmarshalFieldMask(s)
@@ -1638,6 +1858,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_value_map", "stringValueMap":
 			s.AddField("string_value_map")
+			if s.ReadNil() {
+				x.StringValueMap = nil
+				return
+			}
 			x.StringValueMap = make(map[string]*structpb.Value)
 			s.ReadStringMap(func(key string) {
 				v := golang.UnmarshalValue(s)
@@ -1648,6 +1872,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_list_value_map", "stringListValueMap":
 			s.AddField("string_list_value_map")
+			if s.ReadNil() {
+				x.StringListValueMap = nil
+				return
+			}
 			x.StringListValueMap = make(map[string]*structpb.ListValue)
 			s.ReadStringMap(func(key string) {
 				v := golang.UnmarshalListValue(s)
@@ -1658,6 +1886,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_struct_map", "stringStructMap":
 			s.AddField("string_struct_map")
+			if s.ReadNil() {
+				x.StringStructMap = nil
+				return
+			}
 			x.StringStructMap = make(map[string]*structpb.Struct)
 			s.ReadStringMap(func(key string) {
 				v := golang.UnmarshalStruct(s)
@@ -1668,6 +1900,10 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 			})
 		case "string_any_map", "stringAnyMap":
 			s.AddField("string_any_map")
+			if s.ReadNil() {
+				x.StringAnyMap = nil
+				return
+			}
 			x.StringAnyMap = make(map[string]*anypb.Any)
 			s.ReadStringMap(func(key string) {
 				v := golang.UnmarshalAny(s)


### PR DESCRIPTION
This pull request fixes unmarshaling of `null` fields.

Previously, when reading `null` fields, we would in some cases still set the field to an empty map or message, instead of actually setting it to `nil`.

With this pull request, we make sure that when reading `null`, we set the field to `nil` (except for `google.protobuf.Value`, where we set the field to a `google.protobuf.NullValue`).