### PR TITLE
Treat enums with prefix option as having aliases

### DIFF
--- a/internal/gen/enums.go
+++ b/internal/gen/enums.go
@@ -4,6 +4,8 @@
 package gen
 
 import (
+	"strings"
+
 	"github.com/TheThingsIndustries/protoc-gen-go-json/annotations"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/proto"
@@ -42,6 +44,14 @@ func (*generator) enumHasCustomValues(enum *protogen.Enum) bool {
 }
 
 func (*generator) enumHasCustomAliases(enum *protogen.Enum) bool {
+	ext, _ := proto.GetExtension(enum.Desc.Options().(*descriptorpb.EnumOptions), annotations.E_Enum).(*annotations.EnumOptions)
+	prefix := strings.TrimSuffix(ext.GetPrefix(), "_") + "_"
+
+	// The enum has a prefix, so the aliases are the non-prefixed values.
+	if prefix != "_" {
+		return true
+	}
+
 	for _, value := range enum.Values {
 		// If the file has the (thethings.json.enum_value) option, and a value is set, or aliases are set, we have custom aliases.
 		opts := value.Desc.Options().(*descriptorpb.EnumValueOptions)

--- a/test/gogo/enums_test.go
+++ b/test/gogo/enums_test.go
@@ -1,6 +1,7 @@
 package test_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/TheThingsIndustries/protoc-gen-go-json/test/gogo"
@@ -167,6 +168,39 @@ func TestUnmarshalMessageWithOneofEnums(t *testing.T) {
 	for _, tt := range testMessagesWithWithOneofEnums {
 		t.Run(tt.name, func(t *testing.T) {
 			expectUnmarshalEqual(t, &tt.msg, []byte(tt.expected), tt.expectedMask)
+		})
+	}
+}
+
+func TestCustomEnum_TextMarshalers(t *testing.T) {
+	for _, tt := range []struct {
+		enum   CustomEnum
+		values []string
+	}{
+		{CustomEnum_CUSTOM_UNKNOWN, []string{"CUSTOM_UNKNOWN", "UNKNOWN", "0"}},
+		{CustomEnum_CUSTOM_V1_0, []string{"1.0", "1.0.0", "CUSTOM_V1_0", "V1_0", "1"}},
+		{CustomEnum_CUSTOM_V1_0_1, []string{"1.0.1", "CUSTOM_V1_0_1", "V1_0_1", "2"}},
+	} {
+		t.Run(fmt.Sprintf("MarshalText_%s", tt.enum), func(t *testing.T) {
+			txt, err := tt.enum.MarshalText()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(txt) != tt.values[0] {
+				t.Errorf("expected: %s, got: %s", tt.values[0], string(txt))
+			}
+		})
+		t.Run(fmt.Sprintf("UnmarshalText_%s", tt.enum), func(t *testing.T) {
+			for _, value := range tt.values {
+				var enum CustomEnum
+				err := enum.UnmarshalText([]byte(value))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if enum != tt.enum {
+					t.Errorf("expected %q to unmarshal as %s, got: %s", value, tt.enum, enum)
+				}
+			}
 		})
 	}
 }

--- a/test/golang/enums_test.go
+++ b/test/golang/enums_test.go
@@ -1,6 +1,7 @@
 package test_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/TheThingsIndustries/protoc-gen-go-json/test/golang"
@@ -167,6 +168,39 @@ func TestUnmarshalMessageWithOneofEnums(t *testing.T) {
 	for _, tt := range testMessagesWithWithOneofEnums {
 		t.Run(tt.name, func(t *testing.T) {
 			expectUnmarshalEqual(t, &tt.msg, []byte(tt.expected), tt.expectedMask)
+		})
+	}
+}
+
+func TestCustomEnum_TextMarshalers(t *testing.T) {
+	for _, tt := range []struct {
+		enum   CustomEnum
+		values []string
+	}{
+		{CustomEnum_CUSTOM_UNKNOWN, []string{"CUSTOM_UNKNOWN", "UNKNOWN", "0"}},
+		{CustomEnum_CUSTOM_V1_0, []string{"1.0", "1.0.0", "CUSTOM_V1_0", "V1_0", "1"}},
+		{CustomEnum_CUSTOM_V1_0_1, []string{"1.0.1", "CUSTOM_V1_0_1", "V1_0_1", "2"}},
+	} {
+		t.Run(fmt.Sprintf("MarshalText_%s", tt.enum), func(t *testing.T) {
+			txt, err := tt.enum.MarshalText()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(txt) != tt.values[0] {
+				t.Errorf("expected: %s, got: %s", tt.values[0], string(txt))
+			}
+		})
+		t.Run(fmt.Sprintf("UnmarshalText_%s", tt.enum), func(t *testing.T) {
+			for _, value := range tt.values {
+				var enum CustomEnum
+				err := enum.UnmarshalText([]byte(value))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if enum != tt.enum {
+					t.Errorf("expected %q to unmarshal as %s, got: %s", value, tt.enum, enum)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
This is a small fix that avoids a confusion about whether `enumHasCustomAliases` checks for prefixes and custom values in addition to custom aliases.


This fixes an issue where generated `UnmarshalText` methods of prefixed enums without value aliases didn't recognize non-prefixed enum strings:


```diff 
 // UnmarshalText unmarshals the State from text.
 func (x *State) UnmarshalText(b []byte) error {
-	i, err := jsonplugin.ParseEnumString(string(b), State_value)
+	i, err := jsonplugin.ParseEnumString(string(b), State_customvalue, State_value)
 	if err != nil {
 		return err
 	}
```

