### PR TITLE
Support object notation for WKT wrappers

### DIFF
--- a/internal/gen/messages_unmarshaler.go
+++ b/internal/gen/messages_unmarshaler.go
@@ -437,23 +437,23 @@ func (g *generator) genStdMessageUnmarshaler(message *protogen.Message) {
 func (g *generator) readWrapperValue(message *protogen.Message) string {
 	switch message.Desc.FullName() {
 	case "google.protobuf.DoubleValue":
-		return "s.ReadFloat64()"
+		return "s.ReadWrappedFloat64()"
 	case "google.protobuf.FloatValue":
-		return "s.ReadFloat32()"
+		return "s.ReadWrappedFloat32()"
 	case "google.protobuf.Int64Value":
-		return "s.ReadInt64()"
+		return "s.ReadWrappedInt64()"
 	case "google.protobuf.UInt64Value":
-		return "s.ReadUint64()"
+		return "s.ReadWrappedUint64()"
 	case "google.protobuf.Int32Value":
-		return "s.ReadInt32()"
+		return "s.ReadWrappedInt32()"
 	case "google.protobuf.UInt32Value":
-		return "s.ReadUint32()"
+		return "s.ReadWrappedUint32()"
 	case "google.protobuf.BoolValue":
-		return "s.ReadBool()"
+		return "s.ReadWrappedBool()"
 	case "google.protobuf.StringValue":
-		return "s.ReadString()"
+		return "s.ReadWrappedString()"
 	case "google.protobuf.BytesValue":
-		return "s.ReadBytes()"
+		return "s.ReadWrappedBytes()"
 	default:
 		g.gen.Error(fmt.Errorf("unsupported wrapper %q", message.Desc.FullName()))
 		return ""

--- a/jsonplugin/unmarshal.go
+++ b/jsonplugin/unmarshal.go
@@ -156,6 +156,26 @@ func (s *UnmarshalState) ReadFloat32() float32 {
 	}
 }
 
+// ReadWrappedFloat32 reads a wrapped float32 value. This also supports string encoding as well as {"value": ...}.
+func (s *UnmarshalState) ReadWrappedFloat32() float32 {
+	if s.Err() != nil {
+		return 0
+	}
+	if s.inner.WhatIsNext() != jsoniter.ObjectValue {
+		return s.ReadFloat32()
+	}
+	if key := s.ReadObjectField(); key != "value" {
+		s.SetErrorf("first field in wrapped float32 is not value, but %q", key)
+		return 0
+	}
+	v := s.ReadFloat32()
+	if field := s.ReadObjectField(); field != "" {
+		s.SetErrorf("unexpected %q field in wrapped float32", field)
+		return 0
+	}
+	return v
+}
+
 // ReadFloat64 reads a float64 value. This also supports string encoding.
 func (s *UnmarshalState) ReadFloat64() float64 {
 	if s.Err() != nil {
@@ -175,6 +195,26 @@ func (s *UnmarshalState) ReadFloat64() float64 {
 		s.SetErrorf("invalid value type for float64: %s", valueTypeString(any.ValueType()))
 		return 0
 	}
+}
+
+// ReadWrappedFloat64 reads a wrapped float64 value. This also supports string encoding as well as {"value": ...}.
+func (s *UnmarshalState) ReadWrappedFloat64() float64 {
+	if s.Err() != nil {
+		return 0
+	}
+	if s.inner.WhatIsNext() != jsoniter.ObjectValue {
+		return s.ReadFloat64()
+	}
+	if key := s.ReadObjectField(); key != "value" {
+		s.SetErrorf("first field in wrapped float64 is not value, but %q", key)
+		return 0
+	}
+	v := s.ReadFloat64()
+	if field := s.ReadObjectField(); field != "" {
+		s.SetErrorf("unexpected %q field in wrapped float64", field)
+		return 0
+	}
+	return v
 }
 
 // ReadFloat32Array reads an array of float32 values.
@@ -230,6 +270,26 @@ func (s *UnmarshalState) ReadInt32() int32 {
 	}
 }
 
+// ReadWrappedInt32 reads a wrapped int32 value. This also supports string encoding as well as {"value": ...}.
+func (s *UnmarshalState) ReadWrappedInt32() int32 {
+	if s.Err() != nil {
+		return 0
+	}
+	if s.inner.WhatIsNext() != jsoniter.ObjectValue {
+		return s.ReadInt32()
+	}
+	if key := s.ReadObjectField(); key != "value" {
+		s.SetErrorf("first field in wrapped int32 is not value, but %q", key)
+		return 0
+	}
+	v := s.ReadInt32()
+	if field := s.ReadObjectField(); field != "" {
+		s.SetErrorf("unexpected %q field in wrapped int32", field)
+		return 0
+	}
+	return v
+}
+
 // ReadInt64 reads a int64 value. This also supports string encoding.
 func (s *UnmarshalState) ReadInt64() int64 {
 	if s.Err() != nil {
@@ -249,6 +309,26 @@ func (s *UnmarshalState) ReadInt64() int64 {
 		s.SetErrorf("invalid value type for int64: %s", valueTypeString(any.ValueType()))
 		return 0
 	}
+}
+
+// ReadWrappedInt64 reads a wrapped int64 value. This also supports string encoding as well as {"value": ...}.
+func (s *UnmarshalState) ReadWrappedInt64() int64 {
+	if s.Err() != nil {
+		return 0
+	}
+	if s.inner.WhatIsNext() != jsoniter.ObjectValue {
+		return s.ReadInt64()
+	}
+	if key := s.ReadObjectField(); key != "value" {
+		s.SetErrorf("first field in wrapped int64 is not value, but %q", key)
+		return 0
+	}
+	v := s.ReadInt64()
+	if field := s.ReadObjectField(); field != "" {
+		s.SetErrorf("unexpected %q field in wrapped int64", field)
+		return 0
+	}
+	return v
 }
 
 // ReadInt32Array reads an array of int32 values.
@@ -304,6 +384,26 @@ func (s *UnmarshalState) ReadUint32() uint32 {
 	}
 }
 
+// ReadWrappedUint32 reads a wrapped uint32 value. This also supports string encoding as well as {"value": ...}.
+func (s *UnmarshalState) ReadWrappedUint32() uint32 {
+	if s.Err() != nil {
+		return 0
+	}
+	if s.inner.WhatIsNext() != jsoniter.ObjectValue {
+		return s.ReadUint32()
+	}
+	if key := s.ReadObjectField(); key != "value" {
+		s.SetErrorf("first field in wrapped uint32 is not value, but %q", key)
+		return 0
+	}
+	v := s.ReadUint32()
+	if field := s.ReadObjectField(); field != "" {
+		s.SetErrorf("unexpected %q field in wrapped uint32", field)
+		return 0
+	}
+	return v
+}
+
 // ReadUint64 reads a uint64 value. This also supports string encoding.
 func (s *UnmarshalState) ReadUint64() uint64 {
 	if s.Err() != nil {
@@ -323,6 +423,26 @@ func (s *UnmarshalState) ReadUint64() uint64 {
 		s.SetErrorf("invalid value type for uint64: %s", valueTypeString(any.ValueType()))
 		return 0
 	}
+}
+
+// ReadWrappedUint64 reads a wrapped uint64 value. This also supports string encoding as well as {"value": ...}.
+func (s *UnmarshalState) ReadWrappedUint64() uint64 {
+	if s.Err() != nil {
+		return 0
+	}
+	if s.inner.WhatIsNext() != jsoniter.ObjectValue {
+		return s.ReadUint64()
+	}
+	if key := s.ReadObjectField(); key != "value" {
+		s.SetErrorf("first field in wrapped uint64 is not value, but %q", key)
+		return 0
+	}
+	v := s.ReadUint64()
+	if field := s.ReadObjectField(); field != "" {
+		s.SetErrorf("unexpected %q field in wrapped uint64", field)
+		return 0
+	}
+	return v
 }
 
 // ReadUint32Array reads an array of uint32 values.
@@ -365,6 +485,26 @@ func (s *UnmarshalState) ReadBool() bool {
 	return s.inner.ReadBool()
 }
 
+// ReadWrappedBool reads a wrapped bool value. This also supports {"value": ...}.
+func (s *UnmarshalState) ReadWrappedBool() bool {
+	if s.Err() != nil {
+		return false
+	}
+	if s.inner.WhatIsNext() != jsoniter.ObjectValue {
+		return s.ReadBool()
+	}
+	if key := s.ReadObjectField(); key != "value" {
+		s.SetErrorf("first field in wrapped bool is not value, but %q", key)
+		return false
+	}
+	v := s.ReadBool()
+	if field := s.ReadObjectField(); field != "" {
+		s.SetErrorf("unexpected %q field in wrapped bool", field)
+		return false
+	}
+	return v
+}
+
 // ReadBoolArray reads an array of bool values.
 func (s *UnmarshalState) ReadBoolArray() []bool {
 	var arr []bool
@@ -387,6 +527,26 @@ func (s *UnmarshalState) ReadString() string {
 		return ""
 	}
 	return s.inner.ReadString()
+}
+
+// ReadWrappedString reads a wrapped string value. This also supports {"value": ...}.
+func (s *UnmarshalState) ReadWrappedString() string {
+	if s.Err() != nil {
+		return ""
+	}
+	if s.inner.WhatIsNext() != jsoniter.ObjectValue {
+		return s.ReadString()
+	}
+	if key := s.ReadObjectField(); key != "value" {
+		s.SetErrorf("first field in wrapped string is not value, but %q", key)
+		return ""
+	}
+	v := s.ReadString()
+	if field := s.ReadObjectField(); field != "" {
+		s.SetErrorf("unexpected %q field in wrapped string", field)
+		return ""
+	}
+	return v
 }
 
 // ReadStringArray reads an array of string values.
@@ -424,6 +584,26 @@ func (s *UnmarshalState) ReadBytes() []byte {
 	v, err := base64.RawStdEncoding.DecodeString(b64)
 	if err != nil {
 		s.SetErrorf("invalid value: %w", err)
+		return nil
+	}
+	return v
+}
+
+// ReadWrappedBytes reads a wrapped bytes value. This also supports {"value": ...}.
+func (s *UnmarshalState) ReadWrappedBytes() []byte {
+	if s.Err() != nil {
+		return nil
+	}
+	if s.inner.WhatIsNext() != jsoniter.ObjectValue {
+		return s.ReadBytes()
+	}
+	if key := s.ReadObjectField(); key != "value" {
+		s.SetErrorf("first field in wrapped bytes is not value, but %q", key)
+		return nil
+	}
+	v := s.ReadBytes()
+	if field := s.ReadObjectField(); field != "" {
+		s.SetErrorf("unexpected %q field in wrapped bytes", field)
 		return nil
 	}
 	return v

--- a/test/gogo/wkts_json.pb.go
+++ b/test/gogo/wkts_json.pb.go
@@ -493,7 +493,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.DoubleValue = nil
 				return
 			}
-			v := s.ReadFloat64()
+			v := s.ReadWrappedFloat64()
 			if s.Err() != nil {
 				return
 			}
@@ -509,7 +509,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.DoubleValues = append(x.DoubleValues, nil)
 					return
 				}
-				v := s.ReadFloat64()
+				v := s.ReadWrappedFloat64()
 				if s.Err() != nil {
 					return
 				}
@@ -521,7 +521,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.FloatValue = nil
 				return
 			}
-			v := s.ReadFloat32()
+			v := s.ReadWrappedFloat32()
 			if s.Err() != nil {
 				return
 			}
@@ -537,7 +537,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.FloatValues = append(x.FloatValues, nil)
 					return
 				}
-				v := s.ReadFloat32()
+				v := s.ReadWrappedFloat32()
 				if s.Err() != nil {
 					return
 				}
@@ -549,7 +549,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.Int32Value = nil
 				return
 			}
-			v := s.ReadInt32()
+			v := s.ReadWrappedInt32()
 			if s.Err() != nil {
 				return
 			}
@@ -565,7 +565,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.Int32Values = append(x.Int32Values, nil)
 					return
 				}
-				v := s.ReadInt32()
+				v := s.ReadWrappedInt32()
 				if s.Err() != nil {
 					return
 				}
@@ -577,7 +577,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.Int64Value = nil
 				return
 			}
-			v := s.ReadInt64()
+			v := s.ReadWrappedInt64()
 			if s.Err() != nil {
 				return
 			}
@@ -593,7 +593,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.Int64Values = append(x.Int64Values, nil)
 					return
 				}
-				v := s.ReadInt64()
+				v := s.ReadWrappedInt64()
 				if s.Err() != nil {
 					return
 				}
@@ -605,7 +605,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.Uint32Value = nil
 				return
 			}
-			v := s.ReadUint32()
+			v := s.ReadWrappedUint32()
 			if s.Err() != nil {
 				return
 			}
@@ -621,7 +621,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.Uint32Values = append(x.Uint32Values, nil)
 					return
 				}
-				v := s.ReadUint32()
+				v := s.ReadWrappedUint32()
 				if s.Err() != nil {
 					return
 				}
@@ -633,7 +633,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.Uint64Value = nil
 				return
 			}
-			v := s.ReadUint64()
+			v := s.ReadWrappedUint64()
 			if s.Err() != nil {
 				return
 			}
@@ -649,7 +649,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.Uint64Values = append(x.Uint64Values, nil)
 					return
 				}
-				v := s.ReadUint64()
+				v := s.ReadWrappedUint64()
 				if s.Err() != nil {
 					return
 				}
@@ -661,7 +661,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.BoolValue = nil
 				return
 			}
-			v := s.ReadBool()
+			v := s.ReadWrappedBool()
 			if s.Err() != nil {
 				return
 			}
@@ -677,7 +677,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.BoolValues = append(x.BoolValues, nil)
 					return
 				}
-				v := s.ReadBool()
+				v := s.ReadWrappedBool()
 				if s.Err() != nil {
 					return
 				}
@@ -689,7 +689,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.StringValue = nil
 				return
 			}
-			v := s.ReadString()
+			v := s.ReadWrappedString()
 			if s.Err() != nil {
 				return
 			}
@@ -705,7 +705,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.StringValues = append(x.StringValues, nil)
 					return
 				}
-				v := s.ReadString()
+				v := s.ReadWrappedString()
 				if s.Err() != nil {
 					return
 				}
@@ -717,7 +717,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.BytesValue = nil
 				return
 			}
-			v := s.ReadBytes()
+			v := s.ReadWrappedBytes()
 			if s.Err() != nil {
 				return
 			}
@@ -733,7 +733,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.BytesValues = append(x.BytesValues, nil)
 					return
 				}
-				v := s.ReadBytes()
+				v := s.ReadWrappedBytes()
 				if s.Err() != nil {
 					return
 				}
@@ -1113,7 +1113,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.DoubleValue = nil
 				return
 			}
-			v := s.ReadFloat64()
+			v := s.ReadWrappedFloat64()
 			if s.Err() != nil {
 				return
 			}
@@ -1126,7 +1126,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.FloatValue = nil
 				return
 			}
-			v := s.ReadFloat32()
+			v := s.ReadWrappedFloat32()
 			if s.Err() != nil {
 				return
 			}
@@ -1139,7 +1139,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.Int32Value = nil
 				return
 			}
-			v := s.ReadInt32()
+			v := s.ReadWrappedInt32()
 			if s.Err() != nil {
 				return
 			}
@@ -1152,7 +1152,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.Int64Value = nil
 				return
 			}
-			v := s.ReadInt64()
+			v := s.ReadWrappedInt64()
 			if s.Err() != nil {
 				return
 			}
@@ -1165,7 +1165,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.Uint32Value = nil
 				return
 			}
-			v := s.ReadUint32()
+			v := s.ReadWrappedUint32()
 			if s.Err() != nil {
 				return
 			}
@@ -1178,7 +1178,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.Uint64Value = nil
 				return
 			}
-			v := s.ReadUint64()
+			v := s.ReadWrappedUint64()
 			if s.Err() != nil {
 				return
 			}
@@ -1191,7 +1191,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.BoolValue = nil
 				return
 			}
-			v := s.ReadBool()
+			v := s.ReadWrappedBool()
 			if s.Err() != nil {
 				return
 			}
@@ -1204,7 +1204,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.StringValue = nil
 				return
 			}
-			v := s.ReadString()
+			v := s.ReadWrappedString()
 			if s.Err() != nil {
 				return
 			}
@@ -1217,7 +1217,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.BytesValue = nil
 				return
 			}
-			v := s.ReadBytes()
+			v := s.ReadWrappedBytes()
 			if s.Err() != nil {
 				return
 			}
@@ -1643,7 +1643,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringDoubleMap[key] = nil
 				} else {
-					v := s.ReadFloat64()
+					v := s.ReadWrappedFloat64()
 					if s.Err() != nil {
 						return
 					}
@@ -1661,7 +1661,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringFloatMap[key] = nil
 				} else {
-					v := s.ReadFloat32()
+					v := s.ReadWrappedFloat32()
 					if s.Err() != nil {
 						return
 					}
@@ -1679,7 +1679,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringInt32Map[key] = nil
 				} else {
-					v := s.ReadInt32()
+					v := s.ReadWrappedInt32()
 					if s.Err() != nil {
 						return
 					}
@@ -1697,7 +1697,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringInt64Map[key] = nil
 				} else {
-					v := s.ReadInt64()
+					v := s.ReadWrappedInt64()
 					if s.Err() != nil {
 						return
 					}
@@ -1715,7 +1715,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringUint32Map[key] = nil
 				} else {
-					v := s.ReadUint32()
+					v := s.ReadWrappedUint32()
 					if s.Err() != nil {
 						return
 					}
@@ -1733,7 +1733,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringUint64Map[key] = nil
 				} else {
-					v := s.ReadUint64()
+					v := s.ReadWrappedUint64()
 					if s.Err() != nil {
 						return
 					}
@@ -1751,7 +1751,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringBoolMap[key] = nil
 				} else {
-					v := s.ReadBool()
+					v := s.ReadWrappedBool()
 					if s.Err() != nil {
 						return
 					}
@@ -1769,7 +1769,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringStringMap[key] = nil
 				} else {
-					v := s.ReadString()
+					v := s.ReadWrappedString()
 					if s.Err() != nil {
 						return
 					}
@@ -1787,7 +1787,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringBytesMap[key] = nil
 				} else {
-					v := s.ReadBytes()
+					v := s.ReadWrappedBytes()
 					if s.Err() != nil {
 						return
 					}

--- a/test/gogo/wkts_test.go
+++ b/test/gogo/wkts_test.go
@@ -46,10 +46,11 @@ func mustAny(pb proto.Message) *types.Any {
 }
 
 var testMessagesWithWKTs = []struct {
-	name         string
-	msg          MessageWithWKTs
-	expected     string
-	expectedMask []string
+	name          string
+	msg           MessageWithWKTs
+	unmarshalOnly bool
+	expected      string
+	expectedMask  []string
 }{
 	{
 		name:     "empty",
@@ -394,10 +395,108 @@ var testMessagesWithWKTs = []struct {
 			"any_values",
 		},
 	},
+	{
+		name: "wrappers",
+		msg: MessageWithWKTs{
+			DoubleValue: &types.DoubleValue{Value: 12.34},
+			DoubleValues: []*types.DoubleValue{
+				{Value: 12.34},
+				{Value: 56.78},
+			},
+			FloatValue: &types.FloatValue{Value: 12.34},
+			FloatValues: []*types.FloatValue{
+				{Value: 12.34},
+				{Value: 56.78},
+			},
+			Int32Value: &types.Int32Value{Value: -42},
+			Int32Values: []*types.Int32Value{
+				{Value: 1},
+				{Value: 2},
+				{Value: -42},
+			},
+			Int64Value: &types.Int64Value{Value: -42},
+			Int64Values: []*types.Int64Value{
+				{Value: 1},
+				{Value: 2},
+				{Value: -42},
+			},
+			Uint32Value: &types.UInt32Value{Value: 42},
+			Uint32Values: []*types.UInt32Value{
+				{Value: 1},
+				{Value: 2},
+				{Value: 42},
+			},
+			Uint64Value: &types.UInt64Value{Value: 42},
+			Uint64Values: []*types.UInt64Value{
+				{Value: 1},
+				{Value: 2},
+				{Value: 42},
+			},
+			BoolValue: &types.BoolValue{Value: true},
+			BoolValues: []*types.BoolValue{
+				{Value: true},
+				{Value: false},
+			},
+			StringValue: &types.StringValue{Value: "foo"},
+			StringValues: []*types.StringValue{
+				{Value: "foo"},
+				{Value: "bar"},
+			},
+			BytesValue: &types.BytesValue{Value: []byte("foo")},
+			BytesValues: []*types.BytesValue{
+				{Value: []byte("foo")},
+				{Value: []byte("bar")},
+			},
+		},
+		unmarshalOnly: true,
+		expected: `{
+			"double_value": {"value": 12.34},
+			"double_values": [{"value": 12.34}, {"value": 56.78}],
+			"float_value": {"value": 12.34},
+			"float_values": [{"value": 12.34}, {"value": 56.78}],
+			"int32_value": {"value": -42},
+			"int32_values": [{"value": 1}, {"value": 2}, {"value": -42}],
+			"int64_value": {"value": "-42"},
+			"int64_values": [{"value": "1"}, {"value": "2"}, {"value": "-42"}],
+			"uint32_value": {"value": 42},
+			"uint32_values": [{"value": 1}, {"value": 2}, {"value": 42}],
+			"uint64_value": {"value": "42"},
+			"uint64_values": [{"value": "1"}, {"value": "2"}, {"value": "42"}],
+			"bool_value": {"value": true},
+			"bool_values": [{"value": true}, {"value": false}],
+			"string_value": {"value": "foo"},
+			"string_values": [{"value": "foo"}, {"value": "bar"}],
+			"bytes_value": {"value": "Zm9v"},
+			"bytes_values": [{"value": "Zm9v"}, {"value": "YmFy"}]
+		}`,
+		expectedMask: []string{
+			"double_value",
+			"double_values",
+			"float_value",
+			"float_values",
+			"int32_value",
+			"int32_values",
+			"int64_value",
+			"int64_values",
+			"uint32_value",
+			"uint32_values",
+			"uint64_value",
+			"uint64_values",
+			"bool_value",
+			"bool_values",
+			"string_value",
+			"string_values",
+			"bytes_value",
+			"bytes_values",
+		},
+	},
 }
 
 func TestMarshalMessageWithWKTs(t *testing.T) {
 	for _, tt := range testMessagesWithWKTs {
+		if tt.unmarshalOnly {
+			continue
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			expectMarshalEqual(t, &tt.msg, tt.expectedMask, []byte(tt.expected))
 		})

--- a/test/golang/wkts_json.pb.go
+++ b/test/golang/wkts_json.pb.go
@@ -499,7 +499,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.DoubleValue = nil
 				return
 			}
-			v := s.ReadFloat64()
+			v := s.ReadWrappedFloat64()
 			if s.Err() != nil {
 				return
 			}
@@ -515,7 +515,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.DoubleValues = append(x.DoubleValues, nil)
 					return
 				}
-				v := s.ReadFloat64()
+				v := s.ReadWrappedFloat64()
 				if s.Err() != nil {
 					return
 				}
@@ -527,7 +527,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.FloatValue = nil
 				return
 			}
-			v := s.ReadFloat32()
+			v := s.ReadWrappedFloat32()
 			if s.Err() != nil {
 				return
 			}
@@ -543,7 +543,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.FloatValues = append(x.FloatValues, nil)
 					return
 				}
-				v := s.ReadFloat32()
+				v := s.ReadWrappedFloat32()
 				if s.Err() != nil {
 					return
 				}
@@ -555,7 +555,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.Int32Value = nil
 				return
 			}
-			v := s.ReadInt32()
+			v := s.ReadWrappedInt32()
 			if s.Err() != nil {
 				return
 			}
@@ -571,7 +571,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.Int32Values = append(x.Int32Values, nil)
 					return
 				}
-				v := s.ReadInt32()
+				v := s.ReadWrappedInt32()
 				if s.Err() != nil {
 					return
 				}
@@ -583,7 +583,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.Int64Value = nil
 				return
 			}
-			v := s.ReadInt64()
+			v := s.ReadWrappedInt64()
 			if s.Err() != nil {
 				return
 			}
@@ -599,7 +599,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.Int64Values = append(x.Int64Values, nil)
 					return
 				}
-				v := s.ReadInt64()
+				v := s.ReadWrappedInt64()
 				if s.Err() != nil {
 					return
 				}
@@ -611,7 +611,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.Uint32Value = nil
 				return
 			}
-			v := s.ReadUint32()
+			v := s.ReadWrappedUint32()
 			if s.Err() != nil {
 				return
 			}
@@ -627,7 +627,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.Uint32Values = append(x.Uint32Values, nil)
 					return
 				}
-				v := s.ReadUint32()
+				v := s.ReadWrappedUint32()
 				if s.Err() != nil {
 					return
 				}
@@ -639,7 +639,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.Uint64Value = nil
 				return
 			}
-			v := s.ReadUint64()
+			v := s.ReadWrappedUint64()
 			if s.Err() != nil {
 				return
 			}
@@ -655,7 +655,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.Uint64Values = append(x.Uint64Values, nil)
 					return
 				}
-				v := s.ReadUint64()
+				v := s.ReadWrappedUint64()
 				if s.Err() != nil {
 					return
 				}
@@ -667,7 +667,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.BoolValue = nil
 				return
 			}
-			v := s.ReadBool()
+			v := s.ReadWrappedBool()
 			if s.Err() != nil {
 				return
 			}
@@ -683,7 +683,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.BoolValues = append(x.BoolValues, nil)
 					return
 				}
-				v := s.ReadBool()
+				v := s.ReadWrappedBool()
 				if s.Err() != nil {
 					return
 				}
@@ -695,7 +695,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.StringValue = nil
 				return
 			}
-			v := s.ReadString()
+			v := s.ReadWrappedString()
 			if s.Err() != nil {
 				return
 			}
@@ -711,7 +711,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.StringValues = append(x.StringValues, nil)
 					return
 				}
-				v := s.ReadString()
+				v := s.ReadWrappedString()
 				if s.Err() != nil {
 					return
 				}
@@ -723,7 +723,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				x.BytesValue = nil
 				return
 			}
-			v := s.ReadBytes()
+			v := s.ReadWrappedBytes()
 			if s.Err() != nil {
 				return
 			}
@@ -739,7 +739,7 @@ func (x *MessageWithWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 					x.BytesValues = append(x.BytesValues, nil)
 					return
 				}
-				v := s.ReadBytes()
+				v := s.ReadWrappedBytes()
 				if s.Err() != nil {
 					return
 				}
@@ -1119,7 +1119,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.DoubleValue = nil
 				return
 			}
-			v := s.ReadFloat64()
+			v := s.ReadWrappedFloat64()
 			if s.Err() != nil {
 				return
 			}
@@ -1132,7 +1132,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.FloatValue = nil
 				return
 			}
-			v := s.ReadFloat32()
+			v := s.ReadWrappedFloat32()
 			if s.Err() != nil {
 				return
 			}
@@ -1145,7 +1145,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.Int32Value = nil
 				return
 			}
-			v := s.ReadInt32()
+			v := s.ReadWrappedInt32()
 			if s.Err() != nil {
 				return
 			}
@@ -1158,7 +1158,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.Int64Value = nil
 				return
 			}
-			v := s.ReadInt64()
+			v := s.ReadWrappedInt64()
 			if s.Err() != nil {
 				return
 			}
@@ -1171,7 +1171,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.Uint32Value = nil
 				return
 			}
-			v := s.ReadUint32()
+			v := s.ReadWrappedUint32()
 			if s.Err() != nil {
 				return
 			}
@@ -1184,7 +1184,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.Uint64Value = nil
 				return
 			}
-			v := s.ReadUint64()
+			v := s.ReadWrappedUint64()
 			if s.Err() != nil {
 				return
 			}
@@ -1197,7 +1197,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.BoolValue = nil
 				return
 			}
-			v := s.ReadBool()
+			v := s.ReadWrappedBool()
 			if s.Err() != nil {
 				return
 			}
@@ -1210,7 +1210,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.StringValue = nil
 				return
 			}
-			v := s.ReadString()
+			v := s.ReadWrappedString()
 			if s.Err() != nil {
 				return
 			}
@@ -1223,7 +1223,7 @@ func (x *MessageWithOneofWKTs) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) 
 				ov.BytesValue = nil
 				return
 			}
-			v := s.ReadBytes()
+			v := s.ReadWrappedBytes()
 			if s.Err() != nil {
 				return
 			}
@@ -1649,7 +1649,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringDoubleMap[key] = nil
 				} else {
-					v := s.ReadFloat64()
+					v := s.ReadWrappedFloat64()
 					if s.Err() != nil {
 						return
 					}
@@ -1667,7 +1667,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringFloatMap[key] = nil
 				} else {
-					v := s.ReadFloat32()
+					v := s.ReadWrappedFloat32()
 					if s.Err() != nil {
 						return
 					}
@@ -1685,7 +1685,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringInt32Map[key] = nil
 				} else {
-					v := s.ReadInt32()
+					v := s.ReadWrappedInt32()
 					if s.Err() != nil {
 						return
 					}
@@ -1703,7 +1703,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringInt64Map[key] = nil
 				} else {
-					v := s.ReadInt64()
+					v := s.ReadWrappedInt64()
 					if s.Err() != nil {
 						return
 					}
@@ -1721,7 +1721,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringUint32Map[key] = nil
 				} else {
-					v := s.ReadUint32()
+					v := s.ReadWrappedUint32()
 					if s.Err() != nil {
 						return
 					}
@@ -1739,7 +1739,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringUint64Map[key] = nil
 				} else {
-					v := s.ReadUint64()
+					v := s.ReadWrappedUint64()
 					if s.Err() != nil {
 						return
 					}
@@ -1757,7 +1757,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringBoolMap[key] = nil
 				} else {
-					v := s.ReadBool()
+					v := s.ReadWrappedBool()
 					if s.Err() != nil {
 						return
 					}
@@ -1775,7 +1775,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringStringMap[key] = nil
 				} else {
-					v := s.ReadString()
+					v := s.ReadWrappedString()
 					if s.Err() != nil {
 						return
 					}
@@ -1793,7 +1793,7 @@ func (x *MessageWithWKTMaps) UnmarshalProtoJSON(s *jsonplugin.UnmarshalState) {
 				if s.ReadNil() {
 					x.StringBytesMap[key] = nil
 				} else {
-					v := s.ReadBytes()
+					v := s.ReadWrappedBytes()
 					if s.Err() != nil {
 						return
 					}

--- a/test/golang/wkts_test.go
+++ b/test/golang/wkts_test.go
@@ -48,10 +48,11 @@ func mustAny(pb proto.Message) *anypb.Any {
 }
 
 var testMessagesWithWKTs = []struct {
-	name         string
-	msg          MessageWithWKTs
-	expected     string
-	expectedMask []string
+	name          string
+	msg           MessageWithWKTs
+	unmarshalOnly bool
+	expected      string
+	expectedMask  []string
 }{
 	{
 		name:     "empty",
@@ -396,10 +397,108 @@ var testMessagesWithWKTs = []struct {
 			"any_values",
 		},
 	},
+	{
+		name: "wrappers",
+		msg: MessageWithWKTs{
+			DoubleValue: &wrapperspb.DoubleValue{Value: 12.34},
+			DoubleValues: []*wrapperspb.DoubleValue{
+				{Value: 12.34},
+				{Value: 56.78},
+			},
+			FloatValue: &wrapperspb.FloatValue{Value: 12.34},
+			FloatValues: []*wrapperspb.FloatValue{
+				{Value: 12.34},
+				{Value: 56.78},
+			},
+			Int32Value: &wrapperspb.Int32Value{Value: -42},
+			Int32Values: []*wrapperspb.Int32Value{
+				{Value: 1},
+				{Value: 2},
+				{Value: -42},
+			},
+			Int64Value: &wrapperspb.Int64Value{Value: -42},
+			Int64Values: []*wrapperspb.Int64Value{
+				{Value: 1},
+				{Value: 2},
+				{Value: -42},
+			},
+			Uint32Value: &wrapperspb.UInt32Value{Value: 42},
+			Uint32Values: []*wrapperspb.UInt32Value{
+				{Value: 1},
+				{Value: 2},
+				{Value: 42},
+			},
+			Uint64Value: &wrapperspb.UInt64Value{Value: 42},
+			Uint64Values: []*wrapperspb.UInt64Value{
+				{Value: 1},
+				{Value: 2},
+				{Value: 42},
+			},
+			BoolValue: &wrapperspb.BoolValue{Value: true},
+			BoolValues: []*wrapperspb.BoolValue{
+				{Value: true},
+				{Value: false},
+			},
+			StringValue: &wrapperspb.StringValue{Value: "foo"},
+			StringValues: []*wrapperspb.StringValue{
+				{Value: "foo"},
+				{Value: "bar"},
+			},
+			BytesValue: &wrapperspb.BytesValue{Value: []byte("foo")},
+			BytesValues: []*wrapperspb.BytesValue{
+				{Value: []byte("foo")},
+				{Value: []byte("bar")},
+			},
+		},
+		unmarshalOnly: true,
+		expected: `{
+			"double_value": {"value": 12.34},
+			"double_values": [{"value": 12.34}, {"value": 56.78}],
+			"float_value": {"value": 12.34},
+			"float_values": [{"value": 12.34}, {"value": 56.78}],
+			"int32_value": {"value": -42},
+			"int32_values": [{"value": 1}, {"value": 2}, {"value": -42}],
+			"int64_value": {"value": "-42"},
+			"int64_values": [{"value": "1"}, {"value": "2"}, {"value": "-42"}],
+			"uint32_value": {"value": 42},
+			"uint32_values": [{"value": 1}, {"value": 2}, {"value": 42}],
+			"uint64_value": {"value": "42"},
+			"uint64_values": [{"value": "1"}, {"value": "2"}, {"value": "42"}],
+			"bool_value": {"value": true},
+			"bool_values": [{"value": true}, {"value": false}],
+			"string_value": {"value": "foo"},
+			"string_values": [{"value": "foo"}, {"value": "bar"}],
+			"bytes_value": {"value": "Zm9v"},
+			"bytes_values": [{"value": "Zm9v"}, {"value": "YmFy"}]
+		}`,
+		expectedMask: []string{
+			"double_value",
+			"double_values",
+			"float_value",
+			"float_values",
+			"int32_value",
+			"int32_values",
+			"int64_value",
+			"int64_values",
+			"uint32_value",
+			"uint32_values",
+			"uint64_value",
+			"uint64_values",
+			"bool_value",
+			"bool_values",
+			"string_value",
+			"string_values",
+			"bytes_value",
+			"bytes_values",
+		},
+	},
 }
 
 func TestMarshalMessageWithWKTs(t *testing.T) {
 	for _, tt := range testMessagesWithWKTs {
+		if tt.unmarshalOnly {
+			continue
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			expectMarshalEqual(t, &tt.msg, tt.expectedMask, []byte(tt.expected))
 		})


### PR DESCRIPTION
This pull request adds new `ReadWrapped{Type}` methods on `UnmarshalState`, intended to unmarshal wrapper WKTs. These methods allow us to accept both `"field": ...` and `"field": {"value": ...}` when unmarshaling.