### PR TITLE
Add `legacy_fieldmask_marshaling` option

### DIFF
--- a/cmd/protoc-gen-go-json/main.go
+++ b/cmd/protoc-gen-go-json/main.go
@@ -22,6 +22,7 @@ func main() {
 
 	var flags flag.FlagSet
 	flags.BoolVar(&plugin.Params.Std, "std", false, "generate standard library (un)marshalers")
+	flags.BoolVar(&plugin.Params.LegacyFieldMaskMarshalling, "legacy_fieldmask_marshaling", false, "generate legacy fieldmask marshalers")
 	flags.StringVar(&plugin.Params.Lang, "lang", "go", "language (go or gogo)")
 
 	protogen.Options{

--- a/gogo/gogo.go
+++ b/gogo/gogo.go
@@ -57,7 +57,7 @@ func UnmarshalMessage(s *jsonplugin.UnmarshalState, v proto.Message) {
 }
 
 // MarshalAny marshals a Any WKT.
-func MarshalAny(s *jsonplugin.MarshalState, v *types.Any) {
+func MarshalAny(s *jsonplugin.MarshalState, v *types.Any, legacyFieldmask bool) {
 	if v == nil {
 		s.WriteNil()
 		return
@@ -141,7 +141,11 @@ func MarshalAny(s *jsonplugin.MarshalState, v *types.Any) {
 		case *types.Duration:
 			MarshalDuration(s, msg)
 		case *types.FieldMask:
-			MarshalFieldMask(s, msg)
+			if legacyFieldmask {
+				MarshalLegacyFieldMask(s, msg)
+			} else {
+				MarshalFieldMask(s, msg)
+			}
 		case *types.Struct:
 			MarshalStruct(s, msg)
 		case *types.Value:
@@ -306,6 +310,14 @@ func MarshalFieldMask(s *jsonplugin.MarshalState, v *types.FieldMask) {
 		return
 	}
 	s.WriteFieldMask(v)
+}
+
+func MarshalLegacyFieldMask(s *jsonplugin.MarshalState, v *types.FieldMask) {
+	if v == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteLegacyFieldMask(v)
 }
 
 // UnmarshalFieldMask unmarshals a FieldMask WKT.

--- a/golang/golang.go
+++ b/golang/golang.go
@@ -63,7 +63,7 @@ func UnmarshalMessage(s *jsonplugin.UnmarshalState, v proto.Message) {
 }
 
 // MarshalAny marshals an Any WKT.
-func MarshalAny(s *jsonplugin.MarshalState, v *anypb.Any) {
+func MarshalAny(s *jsonplugin.MarshalState, v *anypb.Any, legacyFieldmask bool) {
 	if v == nil {
 		s.WriteNil()
 		return
@@ -142,7 +142,11 @@ func MarshalAny(s *jsonplugin.MarshalState, v *anypb.Any) {
 		case *durationpb.Duration:
 			MarshalDuration(s, msg)
 		case *fieldmaskpb.FieldMask:
-			MarshalFieldMask(s, msg)
+			if legacyFieldmask {
+				MarshalLegacyFieldMask(s, msg)
+			} else {
+				MarshalFieldMask(s, msg)
+			}
 		case *structpb.Struct:
 			MarshalStruct(s, msg)
 		case *structpb.Value:
@@ -298,6 +302,14 @@ func MarshalFieldMask(s *jsonplugin.MarshalState, v *fieldmaskpb.FieldMask) {
 		return
 	}
 	s.WriteFieldMask(v)
+}
+
+func MarshalLegacyFieldMask(s *jsonplugin.MarshalState, v *fieldmaskpb.FieldMask) {
+	if v == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteLegacyFieldMask(v)
 }
 
 // UnmarshalFieldMask unmarshals a FieldMask WKT.

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -14,8 +14,9 @@ var Version = "0.0.0-dev"
 
 // Params are the parameters for the generator.
 var Params struct {
-	Lang string
-	Std  bool
+	Lang                       string
+	Std                        bool
+	LegacyFieldMaskMarshalling bool
 }
 
 const (

--- a/internal/gen/messages_marshaler.go
+++ b/internal/gen/messages_marshaler.go
@@ -473,11 +473,15 @@ func (g *generator) writeWKTValue(field *protogen.Field, message *protogen.Messa
 	}
 	switch message.Desc.FullName() {
 	case "google.protobuf.Any":
-		g.P(pluginPackage.Ident("MarshalAny"), "(s, ", ident, ")")
+		g.P(pluginPackage.Ident("MarshalAny"), "(s, ", ident, ", ", Params.LegacyFieldMaskMarshalling, ")")
 	case "google.protobuf.Empty":
 		g.P(pluginPackage.Ident("MarshalEmpty"), "(s, ", ident, ")")
 	case "google.protobuf.FieldMask":
-		g.P(pluginPackage.Ident("MarshalFieldMask"), "(s, ", ident, ")")
+		if Params.LegacyFieldMaskMarshalling {
+			g.P(pluginPackage.Ident("MarshalLegacyFieldMask"), "(s, ", ident, ")")
+		} else {
+			g.P(pluginPackage.Ident("MarshalFieldMask"), "(s, ", ident, ")")
+		}
 	case "google.protobuf.Struct":
 		g.P(pluginPackage.Ident("MarshalStruct"), "(s, ", ident, ")")
 	case "google.protobuf.Value":

--- a/jsonplugin/marshal.go
+++ b/jsonplugin/marshal.go
@@ -581,3 +581,21 @@ func (s *MarshalState) WriteFieldMask(x FieldMask) {
 	paths := x.GetPaths()
 	s.inner.WriteString(strings.Join(paths, ","))
 }
+
+func (s *MarshalState) WriteLegacyFieldMask(x FieldMask) {
+	if s.Err() != nil {
+		return
+	}
+	paths := x.GetPaths()
+	s.inner.WriteObjectStart()
+	s.inner.WriteObjectField("paths")
+	s.inner.WriteArrayStart()
+	for i, path := range paths {
+		if i != 0 {
+			s.inner.WriteMore()
+		}
+		s.inner.WriteString(path)
+	}
+	s.inner.WriteArrayEnd()
+	s.inner.WriteObjectEnd()
+}

--- a/test/gogo/wkts_json.pb.go
+++ b/test/gogo/wkts_json.pb.go
@@ -452,7 +452,7 @@ func (x *MessageWithWKTs) MarshalProtoJSON(s *jsonplugin.MarshalState) {
 		if x.AnyValue == nil {
 			s.WriteNil()
 		} else {
-			gogo.MarshalAny(s, x.AnyValue)
+			gogo.MarshalAny(s, x.AnyValue, false)
 		}
 	}
 	if len(x.AnyValues) > 0 || s.HasField("any_values") {
@@ -465,7 +465,7 @@ func (x *MessageWithWKTs) MarshalProtoJSON(s *jsonplugin.MarshalState) {
 			if element == nil {
 				s.WriteNil()
 			} else {
-				gogo.MarshalAny(s, element)
+				gogo.MarshalAny(s, element, false)
 			}
 		}
 		s.WriteArrayEnd()
@@ -1084,7 +1084,7 @@ func (x *MessageWithOneofWKTs) MarshalProtoJSON(s *jsonplugin.MarshalState) {
 			if ov.AnyValue == nil {
 				s.WriteNil()
 			} else {
-				gogo.MarshalAny(s, ov.AnyValue)
+				gogo.MarshalAny(s, ov.AnyValue, false)
 			}
 		}
 	}
@@ -1610,7 +1610,7 @@ func (x *MessageWithWKTMaps) MarshalProtoJSON(s *jsonplugin.MarshalState) {
 			if v == nil {
 				s.WriteNil()
 			} else {
-				gogo.MarshalAny(s, v)
+				gogo.MarshalAny(s, v, false)
 			}
 		}
 		s.WriteObjectEnd()

--- a/test/golang/wkts_json.pb.go
+++ b/test/golang/wkts_json.pb.go
@@ -458,7 +458,7 @@ func (x *MessageWithWKTs) MarshalProtoJSON(s *jsonplugin.MarshalState) {
 		if x.AnyValue == nil {
 			s.WriteNil()
 		} else {
-			golang.MarshalAny(s, x.AnyValue)
+			golang.MarshalAny(s, x.AnyValue, false)
 		}
 	}
 	if len(x.AnyValues) > 0 || s.HasField("any_values") {
@@ -471,7 +471,7 @@ func (x *MessageWithWKTs) MarshalProtoJSON(s *jsonplugin.MarshalState) {
 			if element == nil {
 				s.WriteNil()
 			} else {
-				golang.MarshalAny(s, element)
+				golang.MarshalAny(s, element, false)
 			}
 		}
 		s.WriteArrayEnd()
@@ -1090,7 +1090,7 @@ func (x *MessageWithOneofWKTs) MarshalProtoJSON(s *jsonplugin.MarshalState) {
 			if ov.AnyValue == nil {
 				s.WriteNil()
 			} else {
-				golang.MarshalAny(s, ov.AnyValue)
+				golang.MarshalAny(s, ov.AnyValue, false)
 			}
 		}
 	}
@@ -1616,7 +1616,7 @@ func (x *MessageWithWKTMaps) MarshalProtoJSON(s *jsonplugin.MarshalState) {
 			if v == nil {
 				s.WriteNil()
 			} else {
-				golang.MarshalAny(s, v)
+				golang.MarshalAny(s, v, false)
 			}
 		}
 		s.WriteObjectEnd()


### PR DESCRIPTION
This adds a flag (`legacy_fieldmask_marshaling`) which will marshall fieldmasks as `{"paths":["a","b"]}` instead of `"a,b"`.