### PR TITLE
Provide error unwrapping

### DIFF
--- a/jsonplugin/marshal.go
+++ b/jsonplugin/marshal.go
@@ -31,6 +31,10 @@ func (e *marshalError) Error() string {
 	return fmt.Sprintf("marshal error: %v", e.Err)
 }
 
+func (e *marshalError) Unwrap() error {
+	return e.Err
+}
+
 // MarshalerConfig is the configuration for the Marshaler.
 type MarshalerConfig struct {
 	EnumsAsInts bool

--- a/jsonplugin/unmarshal.go
+++ b/jsonplugin/unmarshal.go
@@ -31,6 +31,10 @@ func (e *unmarshalError) Error() string {
 	return fmt.Sprintf("unmarshal error: %v", e.Err)
 }
 
+func (e *unmarshalError) Unwrap() error {
+	return e.Err
+}
+
 // UnmarshalerConfig is the configuration for the Unmarshaler.
 type UnmarshalerConfig struct{}
 


### PR DESCRIPTION
References https://github.com/TheThingsNetwork/lorawan-stack/pull/6145

This PR adds the `Unwrap() error` method to the unmarshal and marshal errors in order to allow other packages to unwrap the inner error that may occur during the marshaling process.

See the [errors](https://pkg.go.dev/errors) package.